### PR TITLE
Port Basic.lean to lean4

### DIFF
--- a/ExponentialRamsey.lean
+++ b/ExponentialRamsey.lean
@@ -1,4 +1,4 @@
--- import ExponentialRamsey.Basic
+import ExponentialRamsey.Basic
 -- import ExponentialRamsey.Log2Estimates
 -- import ExponentialRamsey.LogSmall
 -- import ExponentialRamsey.MainResults

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -21,10 +21,6 @@ open scoped BigOperators
 
 variable {V K : Type*}
 
-theorem cast_card_sdiff {α R : Type*} [AddGroupWithOne R] [DecidableEq α] {s t : Finset α}
-    (h : s ⊆ t) : ((t \ s).card : R) = t.card - s.card := by
-  rw [card_sdiff_of_subset h, Nat.cast_sub (card_le_card h)]
-
 /-- For `χ` a labelling and vertex sets `X` `Y` and a label `k`, give the edge density of
 `k`-labelled edges between `X` and `Y`. -/
 def colDensity [DecidableEq V] [DecidableEq K] (χ : TopEdgeLabelling V K) (k : K)

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -931,8 +931,7 @@ theorem redSteps_union_densitySteps :
   intro i hi
   simp only [mem_image, Subtype.exists, mem_filter, mem_attach, true_and, exists_eq_right,
     exists_and_right]
-  refine' ⟨hi, _⟩
-  exact (Classical.em _).imp_right not_le.mp
+  grind
 
 theorem redSteps_disjoint_densitySteps : Disjoint (redSteps μ k l ini) (densitySteps μ k l ini) := by
   rw [redSteps, densitySteps, disjoint_image Subtype.coe_injective, disjoint_filter]

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -147,11 +147,9 @@ theorem qFunction_one {k : ℕ} {p₀ : ℝ} : qFunction k p₀ 1 = p₀ + k ^ (
 theorem q_increasing {k h₁ h₂ : ℕ} {p₀ : ℝ} (h : h₁ ≤ h₂) :
     qFunction k p₀ h₁ ≤ qFunction k p₀ h₂ := by
   simp only [qFunction, add_le_add_iff_left]
-  cases k
-  · simp
-  · rw [div_le_div_iff_of_pos_right (by positivity)]
-    exact sub_le_sub_right
-      (pow_le_pow_right₀ (le_add_of_nonneg_right (Real.rpow_nonneg (Nat.cast_nonneg _) _)) h) 1
+  exact div_le_div_of_nonneg_right (sub_le_sub_right (pow_le_pow_right₀
+    (le_add_of_nonneg_right (Real.rpow_nonneg (Nat.cast_nonneg _) _)) h) 1)
+    (Nat.cast_nonneg _)
 
 theorem qFunction_weak_lower {k : ℕ} {p₀ : ℝ} {h : ℕ} :
     p₀ + h * k ^ (-1 / 4 : ℝ) / k ≤ qFunction k p₀ h := by

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -13,7 +13,6 @@ import Mathlib.Combinatorics.SimpleGraph.Density
 Define the book algorithm with its prerequisites.
 -/
 
-
 open Finset Real
 
 namespace SimpleGraph
@@ -28,8 +27,8 @@ theorem cast_card_sdiff {α R : Type*} [AddGroupWithOne R] [DecidableEq α] {s t
 
 /-- For `χ` a labelling and vertex sets `X` `Y` and a label `k`, give the edge density of
 `k`-labelled edges between `X` and `Y`. -/
-def colDensity [DecidableEq V] [DecidableEq K] (χ : TopEdgeLabelling V K) (k : K) (X Y : Finset V) :
-    ℝ :=
+def colDensity [DecidableEq V] [DecidableEq K] (χ : TopEdgeLabelling V K) (k : K)
+    (X Y : Finset V) : ℝ :=
   edgeDensity (χ.labelGraph k) X Y
 
 theorem colDensity_comm [DecidableEq V] [DecidableEq K] (χ : TopEdgeLabelling V K) (k : K)
@@ -128,7 +127,8 @@ variable [Fintype V]
 /-- Define the weight of an ordered pair for the book algorithm.
 `pair_weight χ X Y x y` corresponds to `ω(x, y)` in the paper, see equation (3).
 -/
-noncomputable def pairWeight [DecidableEq (Fin 2)] (χ : TopEdgeLabelling V (Fin 2)) (X Y : Finset V) (x y : V) : ℝ :=
+noncomputable def pairWeight [DecidableEq (Fin 2)] (χ : TopEdgeLabelling V (Fin 2))
+    (X Y : Finset V) (x y : V) : ℝ :=
   (Y.card : ℝ)⁻¹ *
     (((red_neighbors χ) x ∩ (red_neighbors χ) y ∩ Y).card -
       (red_density χ) X Y * ((red_neighbors χ) x ∩ Y).card)
@@ -136,7 +136,8 @@ noncomputable def pairWeight [DecidableEq (Fin 2)] (χ : TopEdgeLabelling V (Fin
 /-- Define the weight of a vertex for the book algorithm.
 `pair_weight χ X Y x` corresponds to `ω(x)` in the paper, see equation (4).
 -/
-noncomputable def weight [DecidableEq (Fin 2)] (χ : TopEdgeLabelling V (Fin 2)) (X Y : Finset V) (x : V) : ℝ :=
+noncomputable def weight [DecidableEq (Fin 2)] (χ : TopEdgeLabelling V (Fin 2))
+    (X Y : Finset V) (x : V) : ℝ :=
   ∑ y ∈ X.erase x, pairWeight χ X Y x y
 
 end
@@ -151,12 +152,14 @@ theorem qFunction_zero {k : ℕ} {p₀ : ℝ} : qFunction k p₀ 0 = p₀ := by
 theorem qFunction_one {k : ℕ} {p₀ : ℝ} : qFunction k p₀ 1 = p₀ + k ^ (-1 / 4 : ℝ) / k := by
   rw [qFunction, pow_one, add_sub_cancel_left]
 
-theorem q_increasing {k h₁ h₂ : ℕ} {p₀ : ℝ} (h : h₁ ≤ h₂) : qFunction k p₀ h₁ ≤ qFunction k p₀ h₂ := by
+theorem q_increasing {k h₁ h₂ : ℕ} {p₀ : ℝ} (h : h₁ ≤ h₂) :
+    qFunction k p₀ h₁ ≤ qFunction k p₀ h₂ := by
   simp only [qFunction, add_le_add_iff_left]
   cases k
   · simp
   · rw [div_le_div_iff_of_pos_right (by positivity)]
-    exact sub_le_sub_right (pow_le_pow_right₀ (le_add_of_nonneg_right (Real.rpow_nonneg (Nat.cast_nonneg _) _)) h) 1
+    exact sub_le_sub_right
+      (pow_le_pow_right₀ (le_add_of_nonneg_right (Real.rpow_nonneg (Nat.cast_nonneg _) _)) h) 1
 
 theorem qFunction_weak_lower {k : ℕ} {p₀ : ℝ} {h : ℕ} :
     p₀ + h * k ^ (-1 / 4 : ℝ) / k ≤ qFunction k p₀ h :=
@@ -241,8 +244,7 @@ instance : Inhabited (BookConfig χ) :=
   ⟨start ∅⟩
 
 /-- Take a red step for the book algorithm, given `x ∈ X`. -/
-def redStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ
-    where
+def redStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ where
   X := (red_neighbors χ) x ∩ C.X
   y := (red_neighbors χ) x ∩ C.y
   A := insert x C.A
@@ -328,8 +330,7 @@ def bigBlueStepBasic (C : BookConfig χ) (S T : Finset V) (hS : S ⊆ C.X) (hT :
 variable [Fintype V]
 
 /-- Take a density boost step for the book algorithm, given `x ∈ X`. -/
-def densityBoostStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ
-    where
+def densityBoostStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ where
   X := (blue_neighbors χ) x ∩ C.X
   y := (red_neighbors χ) x ∩ C.y
   A := C.A
@@ -355,11 +356,13 @@ def densityBoostStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookCon
     · exact Set.mem_union_right _ (Finset.coe_subset.2 inter_subset_right ha))
   blue_b := by
     rw [insert_eq, coe_union, EdgeLabelling.monochromaticOf_union, coe_singleton]
-    exact ⟨EdgeLabelling.monochromaticOf_singleton, C.blue_b, C.blue_XB.subset_left (by simpa using hx)⟩
+    exact
+      ⟨EdgeLabelling.monochromaticOf_singleton, C.blue_b, C.blue_XB.subset_left (by simpa using hx)⟩
   blue_XB :=
     by
     rw [insert_eq, Finset.coe_union, Finset.coe_singleton,
-      EdgeLabelling.monochromaticBetween_union_right, EdgeLabelling.monochromaticBetween_singleton_right]
+      EdgeLabelling.monochromaticBetween_union_right,
+      EdgeLabelling.monochromaticBetween_singleton_right]
     refine' ⟨_, C.blue_XB.subset_left (Finset.coe_subset.2 inter_subset_right)⟩
     simp (config := { contextual := true }) [mem_colNeighbors']
 
@@ -459,7 +462,13 @@ theorem mem_usefulBlueBooks {μ : ℝ} {X : Finset V} {ST : Finset V × Finset V
           Disjoint ST.1 ST.2 ∧
             χ.MonochromaticOf ST.1 1 ∧
               χ.MonochromaticBetween ST.1 ST.2 1 ∧ μ ^ ST.1.card * X.card / 2 ≤ ST.2.card :=
-  by rw [usefulBlueBooks, mem_filter]; constructor <;> simp [Finset.mem_product, mem_powerset] <;> tauto
+  by
+  rw [usefulBlueBooks, mem_filter]
+  constructor
+  · simp [Finset.mem_product, mem_powerset]
+    tauto
+  · simp [Finset.mem_product, mem_powerset]
+    tauto
 
 theorem mem_usefulBlueBooks' {μ : ℝ} {X S T : Finset V} :
     (S, T) ∈ usefulBlueBooks χ μ X ↔
@@ -474,9 +483,9 @@ theorem exists_useful_blue_book (μ : ℝ) (X : Finset V) : (usefulBlueBooks χ 
   by
   use(∅, X)
   rw [mem_usefulBlueBooks']
-  simp only [empty_subset, Subset.rfl, disjoint_empty_left, coe_empty, EdgeLabelling.monochromaticOf_empty,
-    EdgeLabelling.monochromaticBetween_empty_left, card_empty, pow_zero, one_mul,
-    true_and]
+  simp only [empty_subset, Subset.rfl, disjoint_empty_left, coe_empty,
+    EdgeLabelling.monochromaticOf_empty, EdgeLabelling.monochromaticBetween_empty_left, card_empty,
+    pow_zero, one_mul, true_and]
   exact half_le_self (Nat.cast_nonneg _)
 
 theorem exists_blue_book_one_le_S [Fintype V] (μ : ℝ) (X : Finset V)
@@ -488,8 +497,8 @@ theorem exists_blue_book_one_le_S [Fintype V] (μ : ℝ) (X : Finset V)
   · refine' ⟨⟨{x}, ∅⟩, _, by simp⟩
     rw [mem_usefulBlueBooks']
     simp only [singleton_subset_iff, empty_subset, disjoint_singleton_left, Finset.notMem_empty,
-      not_false_iff, coe_singleton, EdgeLabelling.monochromaticOf_singleton, true_and, hx, Nat.cast_zero,
-      card_singleton, pow_one, card_empty]
+      not_false_iff, coe_singleton, EdgeLabelling.monochromaticOf_singleton, true_and, hx,
+      Nat.cast_zero, card_singleton, pow_one, card_empty]
     constructor
     · rw [Finset.coe_empty]; exact EdgeLabelling.monochromaticBetween_empty_right
     · exact div_nonpos_of_nonpos_of_nonneg
@@ -498,10 +507,9 @@ theorem exists_blue_book_one_le_S [Fintype V] (μ : ℝ) (X : Finset V)
   refine' ⟨⟨{x}, (blue_neighbors χ) x ∩ X⟩, _, by simp⟩
   rw [mem_usefulBlueBooks']
   simp (config := { contextual := true }) only [hx, singleton_subset_iff, disjoint_singleton_left,
-    mem_inter, and_true, coe_singleton, EdgeLabelling.monochromaticOf_singleton, card_singleton, pow_one,
-    true_and, inter_subset_right, not_false_iff, not_mem_colNeighbors,
-    EdgeLabelling.monochromaticBetween_singleton_left, and_imp, mem_colNeighbors,
-    eq_self_iff_true, IsEmpty.exists_iff, forall_exists_index, imp_true_iff]
+    mem_inter, and_true, coe_singleton, EdgeLabelling.monochromaticOf_singleton, card_singleton,
+    pow_one, true_and, inter_subset_right, not_false_iff, not_mem_colNeighbors,
+    EdgeLabelling.monochromaticBetween_singleton_left]
   constructor
   · intro y hy h
     exact (mem_colNeighbors.mp (mem_inter.mp hy).1).choose_spec
@@ -646,17 +654,17 @@ theorem getCentralVertex_condition {μ : ℝ} {k l : ℕ} (C : BookConfig χ)
   have hrpow : (l : ℝ) ^ (2 / 3 : ℝ) ≤ (l : ℝ) ^ (3 / 4 : ℝ) := by
     by_cases hl : 1 ≤ l
     · exact Real.rpow_le_rpow_of_exponent_le (by exact_mod_cast hl) (by norm_num)
-    · push_neg at hl; interval_cases l <;> norm_num
+    · push_neg at hl
+      interval_cases l
+      norm_num
   have hceil : ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊ ≤ ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊ :=
     Nat.ceil_le.2 (hrpow.trans (Nat.le_ceil _))
   have hle : numBigBlues μ C < C.X.card :=
     h₂.trans_le ((ramseyNumber.mono_two le_rfl hceil).trans h₁.le)
-  by_contra hall
-  push_neg at hall
+  by_contra! hall
   have key : (C.X.filter fun x => μ * C.X.card ≤ ((blue_neighbors χ) x ∩ C.X).card) = C.X :=
     Finset.filter_true_of_mem (fun x hx => le_of_lt (hall x hx))
-  have : C.X.card ≤ numBigBlues μ C := by
-    rw [numBigBlues, key]
+  have : C.X.card ≤ numBigBlues μ C := by rw [numBigBlues, key]
   omega
 
 end
@@ -696,8 +704,7 @@ theorem algorithmOption_stays_none {i : ℕ} (hi : algorithmOption μ k l ini i 
 
 theorem algorithmOption_is_some_of {i : ℕ} (hi : ∃ C, algorithmOption μ k l ini (i + 1) = some C) :
     ∃ C, algorithmOption μ k l ini i = some C := by
-  by_contra h
-  push_neg at h
+  by_contra! h
   have h1 : algorithmOption μ k l ini i = none := Option.eq_none_iff_forall_not_mem.mpr h
   have h2 : algorithmOption μ k l ini (i + 1) = none := algorithmOption_stays_none h1
   obtain ⟨C, hC⟩ := hi
@@ -821,7 +828,7 @@ theorem some_algorithm_of_finalStep_le (hi : i ≤ finalStep μ k l ini) :
       omega
     cases h : algorithmOption μ k l ini (Nat.succ i) with
     | none => exact absurd h hnotin
-    | some C => simp [Option.getD_some, h]
+    | some C => simp [Option.getD_some]
 
 theorem condition_fails_at_end (hk : k ≠ 0) (hl : l ≠ 0) :
     (endState μ k l ini).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨
@@ -966,8 +973,8 @@ theorem redSteps_subset_redOrDensitySteps : redSteps μ k l ini ⊆ redOrDensity
   by
   intro i hi
   rw [redSteps] at hi
-  simp only [mem_image, exists_prop, mem_filter, mem_attach, Subtype.exists, exists_eq_right,
-    true_and, exists_and_right, Subtype.coe_mk] at hi
+  simp only [mem_image, mem_filter, mem_attach, Subtype.exists, exists_eq_right, true_and,
+    exists_and_right] at hi
   exact hi.1
 
 theorem densitySteps_subset_redOrDensitySteps :
@@ -975,8 +982,8 @@ theorem densitySteps_subset_redOrDensitySteps :
   by
   intro i hi
   rw [densitySteps] at hi
-  simp only [mem_image, exists_prop, mem_filter, mem_attach, Subtype.exists, exists_eq_right,
-    true_and, exists_and_right, Subtype.coe_mk] at hi
+  simp only [mem_image, mem_filter, mem_attach, Subtype.exists, exists_eq_right, true_and,
+    exists_and_right] at hi
   exact hi.1
 
 theorem redSteps_union_densitySteps :
@@ -988,8 +995,8 @@ theorem redSteps_union_densitySteps :
       _
   rw [redSteps, densitySteps, ← image_union, ← filter_or]
   intro i hi
-  simp only [mem_image, Subtype.exists, Subtype.coe_mk, exists_prop, mem_filter, mem_attach,
-    true_and, exists_eq_right, exists_and_right]
+  simp only [mem_image, Subtype.exists, mem_filter, mem_attach, true_and, exists_eq_right,
+    exists_and_right]
   refine' ⟨hi, _⟩
   exact (Classical.em _).imp_right not_le.mp
 
@@ -1020,8 +1027,8 @@ theorem red_applied {i : ℕ} (hi : i ∈ redSteps μ k l ini) :
         (BookConfig.getCentralVertex_mem_x _ _ _) :=
   by
   rw [redSteps, mem_image] at hi
-  simp only [Subtype.coe_mk, mem_filter, mem_attach, true_and, exists_prop, Subtype.exists,
-    exists_and_right, exists_eq_right] at hi
+  simp only [mem_filter, mem_attach, true_and, Subtype.exists, exists_and_right,
+    exists_eq_right] at hi
   obtain ⟨hi', hi''⟩ := hi
   rw [redOrDensitySteps, mem_filter, ← not_le, mem_range] at hi'
   rw [algorithm_succ hi'.1]
@@ -1037,8 +1044,8 @@ theorem density_applied {i : ℕ} (hi : i ∈ densitySteps μ k l ini) :
         (BookConfig.getCentralVertex_mem_x _ _ _) :=
   by
   rw [densitySteps, mem_image] at hi
-  simp only [Subtype.coe_mk, mem_filter, mem_attach, true_and, exists_prop, Subtype.exists,
-    exists_and_right, exists_eq_right] at hi
+  simp only [mem_filter, mem_attach, true_and, Subtype.exists, exists_and_right,
+    exists_eq_right] at hi
   obtain ⟨hi', hi''⟩ := hi
   rw [redOrDensitySteps, mem_filter, ← not_le, mem_range] at hi'
   rw [algorithm_succ hi'.1]
@@ -1068,13 +1075,13 @@ theorem filter_even_thing {n : ℕ} :
   by
   have : ((range n).filter Even).image Nat.succ ⊆ (range (n + 1)).filter fun i => ¬Even i :=
     by
-    simp only [Finset.subset_iff, mem_filter, mem_image, and_imp, exists_prop, and_assoc,
-      mem_range, forall_exists_index, Nat.succ_eq_add_one]
+    simp only [Finset.subset_iff, mem_filter, mem_image, and_imp, and_assoc, mem_range,
+      forall_exists_index, Nat.succ_eq_add_one]
     rintro _ y hy hy' rfl
     simp [hy, hy', parity_simps]
   rw [← Finset.card_image_of_injective _ Nat.succ_injective]
   refine' (card_le_card this).trans _
-  rw [range_succ, filter_insert]
+  rw [range_add_one, filter_insert]
   split_ifs
   · exact Nat.le_succ _
   exact card_insert_le _ _

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -449,6 +449,7 @@ theorem mem_usefulBlueBooks {μ : ℝ} {X : Finset V} {ST : Finset V × Finset V
           Disjoint ST.1 ST.2 ∧
             χ.MonochromaticOf ST.1 1 ∧
               χ.MonochromaticBetween ST.1 ST.2 1 ∧ μ ^ ST.1.card * X.card / 2 ≤ ST.2.card :=
+  -- TODO: revisit this proof
   by
   rw [usefulBlueBooks, mem_filter]
   constructor

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -36,8 +36,7 @@ theorem colDensity_nonneg [DecidableEq V] [DecidableEq K] {χ : TopEdgeLabelling
   Rat.cast_nonneg.2 (edgeDensity_nonneg _ _ _)
 
 theorem colDensity_le_one [DecidableEq V] [DecidableEq K] {χ : TopEdgeLabelling V K} {k : K}
-    {X Y : Finset V} : colDensity χ k X Y ≤ 1 :=
-  by
+    {X Y : Finset V} : colDensity χ k X Y ≤ 1 := by
   rw [← Rat.cast_one]
   exact Rat.cast_le.2 (edgeDensity_le_one _ _ _)
 
@@ -89,10 +88,8 @@ end
 
 theorem interedges_card_eq_sum {V : Type*} [DecidableEq V] [Fintype V] {G : SimpleGraph V}
     [DecidableRel G.Adj] {A B : Finset V} :
-    (G.interedges A B).card = ∑ x ∈ A, (G.neighborFinset x ∩ B).card :=
-  by
-  have : ∀ e ∈ G.interedges A B, Prod.fst e ∈ A :=
-    by
+    (G.interedges A B).card = ∑ x ∈ A, (G.neighborFinset x ∩ B).card := by
+  have : ∀ e ∈ G.interedges A B, Prod.fst e ∈ A := by
     rintro ⟨e₁, e₂⟩ h
     rw [interedges, Rel.mk_mem_interedges_iff] at h
     exact h.1
@@ -110,8 +107,7 @@ theorem interedges_card_eq_sum {V : Type*} [DecidableEq V] [Fintype V] {G : Simp
 
 theorem colDensity_eq_sum {K : Type*} [Fintype V] [DecidableEq K] {χ : TopEdgeLabelling V K}
     {k : K} {A B : Finset V} :
-    colDensity χ k A B = (∑ x ∈ A, (colNeighbors χ k x ∩ B).card) / (A.card * B.card) :=
-  by
+    colDensity χ k A B = (∑ x ∈ A, (colNeighbors χ k x ∩ B).card) / (A.card * B.card) := by
   rw [colDensity, edgeDensity_def, interedges_card_eq_sum]
   simp only [Nat.cast_sum, Rat.cast_div, Rat.cast_sum, Rat.cast_natCast, Rat.cast_mul]
   rfl
@@ -158,8 +154,7 @@ theorem q_increasing {k h₁ h₂ : ℕ} {p₀ : ℝ} (h : h₁ ≤ h₂) :
       (pow_le_pow_right₀ (le_add_of_nonneg_right (Real.rpow_nonneg (Nat.cast_nonneg _) _)) h) 1
 
 theorem qFunction_weak_lower {k : ℕ} {p₀ : ℝ} {h : ℕ} :
-    p₀ + h * k ^ (-1 / 4 : ℝ) / k ≤ qFunction k p₀ h :=
-  by
+    p₀ + h * k ^ (-1 / 4 : ℝ) / k ≤ qFunction k p₀ h := by
   rw [qFunction, add_le_add_iff_left]
   refine' div_le_div_of_nonneg_right _ (Nat.cast_nonneg _)
   refine' (sub_le_sub_right (one_add_mul_le_pow _ h) _).trans_eq' _
@@ -168,8 +163,7 @@ theorem qFunction_weak_lower {k : ℕ} {p₀ : ℝ} {h : ℕ} :
 
 -- The bound on h here is about k / ε, which is not good enough in general so I'm not gonna bother
 -- exposing it, later I show h ≤ 2 log k / ε works for suff large k, which is what's actually needed
-theorem qFunction_above (p₀ c : ℝ) {k : ℕ} (hk : k ≠ 0) : ∃ h, 1 ≤ h ∧ c ≤ qFunction k p₀ h :=
-  by
+theorem qFunction_above (p₀ c : ℝ) {k : ℕ} (hk : k ≠ 0) : ∃ h, 1 ≤ h ∧ c ≤ qFunction k p₀ h := by
   refine' ⟨max 1 ⌈(c - p₀) * k / k ^ (-1 / 4 : ℝ)⌉₊, le_max_left _ _, _⟩
   refine' (q_increasing (le_max_right _ _)).trans' _
   refine' qFunction_weak_lower.trans' _
@@ -181,8 +175,7 @@ theorem qFunction_above (p₀ c : ℝ) {k : ℕ} (hk : k ≠ 0) : ∃ h, 1 ≤ h
 noncomputable def height (k : ℕ) (p₀ p : ℝ) : ℕ :=
   if h : k ≠ 0 then Nat.find (qFunction_above p₀ p h) else 1
 
-theorem one_le_height {k : ℕ} {p₀ p : ℝ} : 1 ≤ height k p₀ p :=
-  by
+theorem one_le_height {k : ℕ} {p₀ p : ℝ} : 1 ≤ height k p₀ p := by
   rw [height]
   split_ifs with h
   · exact (Nat.find_spec (qFunction_above p₀ p h)).1
@@ -230,8 +223,7 @@ section
 variable [Fintype V]
 
 /-- Given a vertex set `X`, construct the initial configuration where `X` is as given. -/
-def start (X : Finset V) : BookConfig χ :=
-  by
+def start (X : Finset V) : BookConfig χ := by
   refine' ⟨X, Xᶜ, ∅, ∅, disjoint_compl_right, _, _, _, _, _, _, _, _, _⟩
   all_goals simp
 
@@ -350,8 +342,7 @@ def densityBoostStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookCon
     rw [insert_eq, coe_union, EdgeLabelling.monochromaticOf_union, coe_singleton]
     exact
       ⟨EdgeLabelling.monochromaticOf_singleton, C.blue_b, C.blue_XB.subset_left (by simpa using hx)⟩
-  blue_XB :=
-    by
+  blue_XB := by
     rw [insert_eq, Finset.coe_union, Finset.coe_singleton,
       EdgeLabelling.monochromaticBetween_union_right,
       EdgeLabelling.monochromaticBetween_singleton_right]
@@ -467,8 +458,7 @@ theorem mem_usefulBlueBooks' {μ : ℝ} {X S T : Finset V} :
               χ.MonochromaticBetween S T 1 ∧ μ ^ S.card * X.card / 2 ≤ T.card :=
   mem_usefulBlueBooks
 
-theorem exists_useful_blue_book (μ : ℝ) (X : Finset V) : (usefulBlueBooks χ μ X).Nonempty :=
-  by
+theorem exists_useful_blue_book (μ : ℝ) (X : Finset V) : (usefulBlueBooks χ μ X).Nonempty := by
   use(∅, X)
   rw [mem_usefulBlueBooks']
   simp only [empty_subset, Subset.rfl, disjoint_empty_left, coe_empty,
@@ -478,8 +468,7 @@ theorem exists_useful_blue_book (μ : ℝ) (X : Finset V) : (usefulBlueBooks χ 
 
 theorem exists_blue_book_one_le_S [Fintype V] (μ : ℝ) (X : Finset V)
     (hX : ∃ x ∈ X, μ * X.card ≤ ((blue_neighbors χ) x ∩ X).card) :
-    ∃ ST : Finset V × Finset V, ST ∈ usefulBlueBooks χ μ X ∧ 1 ≤ ST.1.card :=
-  by
+    ∃ ST : Finset V × Finset V, ST ∈ usefulBlueBooks χ μ X ∧ 1 ≤ ST.1.card := by
   obtain ⟨x, hx, hx'⟩ := hX
   rcases lt_or_ge μ 0 with h | h
   · refine' ⟨⟨{x}, ∅⟩, _, by simp⟩
@@ -546,15 +535,13 @@ section
 variable [Fintype V]
 
 theorem one_le_card_getBook_fst {μ : ℝ} {X : Finset V}
-    (hX : ∃ x ∈ X, μ * X.card ≤ ((blue_neighbors χ) x ∩ X).card) : 1 ≤ (getBook χ μ X).1.card :=
-  by
+    (hX : ∃ x ∈ X, μ * X.card ≤ ((blue_neighbors χ) x ∩ X).card) : 1 ≤ (getBook χ μ X).1.card := by
   obtain ⟨⟨S, T⟩, hST, hS⟩ := exists_blue_book_one_le_S _ _ hX
   exact hS.trans (getBook_max _ _ hST)
 
 theorem getBook_snd_card_le_X {μ : ℝ} {X : Finset V}
     (hX : ∃ x ∈ X, μ * X.card ≤ ((blue_neighbors χ) x ∩ X).card) :
-    (getBook χ μ X).2.card + 1 ≤ X.card :=
-  by
+    (getBook χ μ X).2.card + 1 ≤ X.card := by
   refine' (add_le_add_right (one_le_card_getBook_fst hX) _).trans _
   rw [add_comm, ← card_union_of_disjoint getBook_disjoints]
   exact card_le_card (union_subset getBook_fst_subset getBook_snd_subset)
@@ -565,8 +552,7 @@ noncomputable def numBigBlues (μ : ℝ) (C : BookConfig χ) : ℕ :=
 
 theorem get_book_condition {μ : ℝ} {k l : ℕ} {C : BookConfig χ} (hk : k ≠ 0) (hl : l ≠ 0)
     (hX : ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ numBigBlues μ C) :
-    ∃ x ∈ C.X, μ * C.X.card ≤ ((blue_neighbors χ) x ∩ C.X).card :=
-  by
+    ∃ x ∈ C.X, μ * C.X.card ≤ ((blue_neighbors χ) x ∩ C.X).card := by
   rw [← filter_nonempty_iff, ← card_pos]
   refine' hX.trans_lt' _
   rw [ramseyNumber_pos, Fin.forall_fin_two]
@@ -768,8 +754,7 @@ variable {i : ℕ}
 
 theorem finalStep_is_none (hk : k ≠ 0) (hl : l ≠ 0) :
     algorithmOption μ k l ini (finalStep μ k l ini + 1) = none :=
-  haveI : {i | algorithmOption μ k l ini (i + 1) = none}.Nonempty :=
-    by
+  haveI : {i | algorithmOption μ k l ini (i + 1) = none}.Nonempty := by
     obtain ⟨i, hi⟩ := algorithmOption_terminates μ ini hk hl
     exact ⟨i, hi⟩
   csInf_mem this
@@ -823,15 +808,13 @@ theorem succeed_of_finalStep_le' (hi : i < finalStep μ k l ini) :
   omega
 
 theorem ramseyNumber_lt_of_lt_finalStep (hi : i < finalStep μ k l ini) :
-    ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] < (algorithm μ k l ini i).X.card :=
-  by
+    ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] < (algorithm μ k l ini i).X.card := by
   have := succeed_of_finalStep_le' hi
   rw [not_or, not_le] at this
   exact this.1
 
 theorem one_div_k_lt_p_of_lt_finalStep (hi : i < finalStep μ k l ini) :
-    1 / (k : ℝ) < (algorithm μ k l ini i).p :=
-  by
+    1 / (k : ℝ) < (algorithm μ k l ini i).p := by
   have := succeed_of_finalStep_le' hi
   rw [not_or, not_le, not_le] at this
   exact this.2
@@ -873,16 +856,14 @@ noncomputable def redOrDensitySteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ)
     ¬Even i ∧ (algorithm μ k l ini i).numBigBlues μ < ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊]
 
 theorem degreeSteps_disjoint_bigBlueSteps_union_redOrDensitySteps :
-    Disjoint (degreeSteps μ k l ini) (bigBlueSteps μ k l ini ∪ redOrDensitySteps μ k l ini) :=
-  by
+    Disjoint (degreeSteps μ k l ini) (bigBlueSteps μ k l ini ∪ redOrDensitySteps μ k l ini) := by
   rw [bigBlueSteps, redOrDensitySteps, ← filter_or, degreeSteps, disjoint_filter]
   intro i hi
   rw [← and_or_left, not_and', Classical.not_not]
   exact Function.const _
 
 theorem bigBlueSteps_disjoint_redOrDensitySteps :
-    Disjoint (bigBlueSteps μ k l ini) (redOrDensitySteps μ k l ini) :=
-  by
+    Disjoint (bigBlueSteps μ k l ini) (redOrDensitySteps μ k l ini) := by
   rw [bigBlueSteps, redOrDensitySteps, disjoint_filter]
   rintro x hx ⟨hx₁, hx₂⟩
   rw [not_and, not_lt]
@@ -891,14 +872,12 @@ theorem bigBlueSteps_disjoint_redOrDensitySteps :
 
 theorem of_mem_redOrDensitySteps₁ {i : ℕ} (hi : i ∈ redOrDensitySteps μ k l ini) :
     ¬((algorithm μ k l ini i).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨
-        (algorithm μ k l ini i).p ≤ 1 / k) :=
-  by
+        (algorithm μ k l ini i).p ≤ 1 / k) := by
   rw [redOrDensitySteps, mem_filter, mem_range] at hi
   exact succeed_of_finalStep_le' hi.1
 
 theorem of_mem_redOrDensitySteps₂ {i : ℕ} (hi : i ∈ redOrDensitySteps μ k l ini) :
-    ¬ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ (algorithm μ k l ini i).numBigBlues μ :=
-  by
+    ¬ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ (algorithm μ k l ini i).numBigBlues μ := by
   rw [redOrDensitySteps, mem_filter, ← not_le] at hi
   exact hi.2.2
 
@@ -930,8 +909,7 @@ noncomputable def densitySteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Fi
       (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.Y) <
         C.p - αFunction k (height k ini.p C.p)
 
-theorem redSteps_subset_redOrDensitySteps : redSteps μ k l ini ⊆ redOrDensitySteps μ k l ini :=
-  by
+theorem redSteps_subset_redOrDensitySteps : redSteps μ k l ini ⊆ redOrDensitySteps μ k l ini := by
   intro i hi
   rw [redSteps] at hi
   simp only [mem_image, mem_filter, mem_attach, Subtype.exists, exists_eq_right, true_and,
@@ -939,8 +917,7 @@ theorem redSteps_subset_redOrDensitySteps : redSteps μ k l ini ⊆ redOrDensity
   exact hi.1
 
 theorem densitySteps_subset_redOrDensitySteps :
-    densitySteps μ k l ini ⊆ redOrDensitySteps μ k l ini :=
-  by
+    densitySteps μ k l ini ⊆ redOrDensitySteps μ k l ini := by
   intro i hi
   rw [densitySteps] at hi
   simp only [mem_image, mem_filter, mem_attach, Subtype.exists, exists_eq_right, true_and,
@@ -948,8 +925,7 @@ theorem densitySteps_subset_redOrDensitySteps :
   exact hi.1
 
 theorem redSteps_union_densitySteps :
-    redSteps μ k l ini ∪ densitySteps μ k l ini = redOrDensitySteps μ k l ini :=
-  by
+    redSteps μ k l ini ∪ densitySteps μ k l ini = redOrDensitySteps μ k l ini := by
   refine'
     Subset.antisymm
       (union_subset redSteps_subset_redOrDensitySteps densitySteps_subset_redOrDensitySteps)
@@ -961,22 +937,19 @@ theorem redSteps_union_densitySteps :
   refine' ⟨hi, _⟩
   exact (Classical.em _).imp_right not_le.mp
 
-theorem redSteps_disjoint_densitySteps : Disjoint (redSteps μ k l ini) (densitySteps μ k l ini) :=
-  by
+theorem redSteps_disjoint_densitySteps : Disjoint (redSteps μ k l ini) (densitySteps μ k l ini) := by
   rw [redSteps, densitySteps, disjoint_image Subtype.coe_injective, disjoint_filter]
   intro x hx
   simp
 
 theorem degree_regularisation_applied {i : ℕ} (hi : i ∈ degreeSteps μ k l ini) :
-    algorithm μ k l ini (i + 1) = (algorithm μ k l ini i).degreeRegularisationStep k ini.p :=
-  by
+    algorithm μ k l ini (i + 1) = (algorithm μ k l ini i).degreeRegularisationStep k ini.p := by
   rw [degreeSteps, mem_filter, mem_range] at hi
   rw [algorithm_succ hi.1]
   exact if_pos hi.2
 
 theorem big_blue_applied {i : ℕ} (hi : i ∈ bigBlueSteps μ k l ini) :
-    algorithm μ k l ini (i + 1) = (algorithm μ k l ini i).bigBlueStep μ :=
-  by
+    algorithm μ k l ini (i + 1) = (algorithm μ k l ini i).bigBlueStep μ := by
   rw [bigBlueSteps, mem_filter, mem_range] at hi
   rw [algorithm_succ hi.1]
   dsimp
@@ -985,8 +958,7 @@ theorem big_blue_applied {i : ℕ} (hi : i ∈ bigBlueSteps μ k l ini) :
 theorem red_applied {i : ℕ} (hi : i ∈ redSteps μ k l ini) :
     algorithm μ k l ini (i + 1) =
       (algorithm μ k l ini i).redStepBasic (getX (redSteps_subset_redOrDensitySteps hi))
-        (BookConfig.getCentralVertex_mem_x _ _ _) :=
-  by
+        (BookConfig.getCentralVertex_mem_x _ _ _) := by
   rw [redSteps, mem_image] at hi
   simp only [mem_filter, mem_attach, true_and, Subtype.exists, exists_and_right,
     exists_eq_right] at hi
@@ -1002,8 +974,7 @@ theorem density_applied {i : ℕ} (hi : i ∈ densitySteps μ k l ini) :
     algorithm μ k l ini (i + 1) =
       (algorithm μ k l ini i).densityBoostStepBasic
         (getX (densitySteps_subset_redOrDensitySteps hi))
-        (BookConfig.getCentralVertex_mem_x _ _ _) :=
-  by
+        (BookConfig.getCentralVertex_mem_x _ _ _) := by
   rw [densitySteps, mem_image] at hi
   simp only [mem_filter, mem_attach, true_and, Subtype.exists, exists_and_right,
     exists_eq_right] at hi
@@ -1017,8 +988,7 @@ theorem density_applied {i : ℕ} (hi : i ∈ densitySteps μ k l ini) :
 
 theorem union_partial_steps :
     redOrDensitySteps μ k l ini ∪ bigBlueSteps μ k l ini ∪ degreeSteps μ k l ini =
-      range (finalStep μ k l ini) :=
-  by
+      range (finalStep μ k l ini) := by
   rw [redOrDensitySteps, bigBlueSteps, ← filter_or, degreeSteps, ← filter_or]
   refine' filter_true_of_mem _
   intro i hi
@@ -1032,10 +1002,8 @@ theorem union_steps :
   by rw [union_right_comm (redSteps _ _ _ _), redSteps_union_densitySteps, union_partial_steps]
 
 theorem filter_even_thing {n : ℕ} :
-    ((range n).filter Even).card ≤ ((range n).filter fun i => ¬Even i).card + 1 :=
-  by
-  have : ((range n).filter Even).image Nat.succ ⊆ (range (n + 1)).filter fun i => ¬Even i :=
-    by
+    ((range n).filter Even).card ≤ ((range n).filter fun i => ¬Even i).card + 1 := by
+  have : ((range n).filter Even).image Nat.succ ⊆ (range (n + 1)).filter fun i => ¬Even i := by
     simp only [Finset.subset_iff, mem_filter, mem_image, and_imp, and_assoc, mem_range,
       forall_exists_index, Nat.succ_eq_add_one]
     rintro _ y hy hy' rfl
@@ -1050,12 +1018,10 @@ theorem filter_even_thing {n : ℕ} :
 theorem num_degreeSteps_le_add :
     (degreeSteps μ k l ini).card ≤
       (redSteps μ k l ini).card + (bigBlueSteps μ k l ini).card + (densitySteps μ k l ini).card +
-        1 :=
-  by
+        1 := by
   have :
     bigBlueSteps μ k l ini ∪ redOrDensitySteps μ k l ini =
-      (range (finalStep μ k l ini)).filter fun i => ¬Even i :=
-    by
+      (range (finalStep μ k l ini)).filter fun i => ¬Even i := by
     rw [bigBlueSteps, redOrDensitySteps, ← filter_or]
     refine' filter_congr _
     intro i hi
@@ -1073,8 +1039,7 @@ theorem cases_of_lt_finalStep {i : ℕ} (hi : i < finalStep μ k l ini) :
 
 -- (7)
 theorem x_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
-    (algorithm μ k l ini (i + 1)).X ⊆ (algorithm μ k l ini i).X :=
-  by
+    (algorithm μ k l ini (i + 1)).X ⊆ (algorithm μ k l ini i).X := by
   rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
   · rw [red_applied hi', BookConfig.redStepBasic_x]
     exact inter_subset_right
@@ -1087,8 +1052,7 @@ theorem x_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
 
 -- (7)
 theorem y_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
-    (algorithm μ k l ini (i + 1)).Y ⊆ (algorithm μ k l ini i).Y :=
-  by
+    (algorithm μ k l ini (i + 1)).Y ⊆ (algorithm μ k l ini i).Y := by
   rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
   · rw [red_applied hi', BookConfig.redStepBasic_Y]
     exact inter_subset_right
@@ -1098,8 +1062,7 @@ theorem y_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
   · rw [degree_regularisation_applied hi', BookConfig.degreeRegularisationStep_Y]
 
 theorem a_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
-    (algorithm μ k l ini i).A ⊆ (algorithm μ k l ini (i + 1)).A :=
-  by
+    (algorithm μ k l ini i).A ⊆ (algorithm μ k l ini (i + 1)).A := by
   rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
   · rw [red_applied hi', BookConfig.redStepBasic_a]
     exact subset_insert _ _
@@ -1108,8 +1071,7 @@ theorem a_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
   · rw [degree_regularisation_applied hi', BookConfig.degreeRegularisationStep_a]
 
 theorem b_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
-    (algorithm μ k l ini i).B ⊆ (algorithm μ k l ini (i + 1)).B :=
-  by
+    (algorithm μ k l ini i).B ⊆ (algorithm μ k l ini (i + 1)).B := by
   rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
   · rw [red_applied hi', BookConfig.redStepBasic_b]
   · rw [big_blue_applied hi', BookConfig.bigBlueStep_b]
@@ -1133,8 +1095,7 @@ theorem blueXRatio_eq (hi : i ∈ redOrDensitySteps μ k l ini) :
 -- (8)
 theorem blueXRatio_prop (hi : i ∈ redOrDensitySteps μ k l ini) :
     blueXRatio μ k l ini i * (algorithm μ k l ini i).X.card =
-      ((blue_neighbors χ) (getX hi) ∩ (algorithm μ k l ini i).X).card :=
-  by
+      ((blue_neighbors χ) (getX hi) ∩ (algorithm μ k l ini i).X).card := by
   cases' Finset.eq_empty_or_nonempty (algorithm μ k l ini i).X with hX hX
   · rw [hX, inter_empty, card_empty, Nat.cast_zero, MulZeroClass.mul_zero]
   rw [blueXRatio, dif_pos hi, div_mul_cancel₀]
@@ -1146,8 +1107,7 @@ theorem blueXRatio_nonneg : 0 ≤ blueXRatio μ k l ini i := by
   · positivity
   · exact le_refl 0
 
-theorem blueXRatio_le_mu (hi : i ∈ redOrDensitySteps μ k l ini) : blueXRatio μ k l ini i ≤ μ :=
-  by
+theorem blueXRatio_le_mu (hi : i ∈ redOrDensitySteps μ k l ini) : blueXRatio μ k l ini i ≤ μ := by
   rw [blueXRatio_eq hi]
   have := getX_mem_centralVertices i hi
   rw [BookConfig.centralVertices, mem_filter] at this

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -504,7 +504,7 @@ theorem exists_blue_book_one_le_S [Fintype V] (μ : ℝ) (X : Finset V)
     eq_self_iff_true, IsEmpty.exists_iff, forall_exists_index, imp_true_iff]
   constructor
   · intro y hy h
-    sorry
+    exact (mem_colNeighbors.mp (mem_inter.mp hy).1).choose_spec
   · exact hx'.trans' (half_le_self (mul_nonneg h (Nat.cast_nonneg _)))
 
 theorem exists_maximal_blue_book_aux (χ : TopEdgeLabelling V (Fin 2)) (μ : ℝ) (X : Finset V) :
@@ -705,7 +705,69 @@ theorem algorithmOption_is_some_of {i : ℕ} (hi : ∃ C, algorithmOption μ k l
 
 theorem algorithmOption_x_weak_bound {i : ℕ} (C : BookConfig χ) (hk : k ≠ 0) (hl : l ≠ 0)
     (hC : algorithmOption μ k l ini i = some C) : C.X.card + i / 2 ≤ ini.X.card := by
-  sorry
+  induction i generalizing C with
+  | zero =>
+      simp [algorithmOption] at hC
+      subst C
+      simp
+  | succ i ih =>
+      obtain ⟨C', hC'⟩ := algorithmOption_is_some_of ⟨C, hC⟩
+      have ih' := ih C' hC'
+      unfold algorithmOption at hC
+      rw [hC'] at hC
+      simp only at hC
+      split_ifs at hC with hstop heven hbig hred
+      · injection hC with hC
+        subst C
+        have hcard : (C'.degreeRegularisationStep k ini.p).X.card ≤ C'.X.card :=
+          card_le_card BookConfig.degreeRegularisationStep_x_subset
+        have hdiv : (i + 1) / 2 = i / 2 := by
+          obtain ⟨r, rfl⟩ := heven
+          omega
+        omega
+      · injection hC with hC
+        subst C
+        have hcard : (C'.bigBlueStep μ).X.card + 1 ≤ C'.X.card := by
+          rw [BookConfig.bigBlueStep_x]
+          exact BookConfig.getBook_snd_card_le_X (BookConfig.get_book_condition hk hl hbig)
+        have hdiv : (i + 1) / 2 = i / 2 + 1 := by
+          obtain ⟨r, rfl⟩ := Nat.not_even_iff_odd.mp heven
+          omega
+        omega
+      · injection hC with hC
+        subst C
+        let x := C'.getCentralVertex μ (C'.getCentralVertex_condition hstop hbig)
+        have hx : x ∈ C'.X := BookConfig.getCentralVertex_mem_x _ _ _
+        have hlt : ((red_neighbors χ) x ∩ C'.X).card < C'.X.card := by
+          refine card_lt_card ?_
+          exact (ssubset_iff_of_subset inter_subset_right).2
+            ⟨x, hx, by simp [not_mem_colNeighbors]⟩
+        have hcard : (C'.redStepBasic x hx).X.card + 1 ≤ C'.X.card := by
+          rw [BookConfig.redStepBasic_x]
+          omega
+        have hdiv : (i + 1) / 2 = i / 2 + 1 := by
+          obtain ⟨r, rfl⟩ := Nat.not_even_iff_odd.mp heven
+          omega
+        rw [BookConfig.redStepBasic_x]
+        dsimp only [x] at hlt hcard
+        omega
+      · injection hC with hC
+        subst C
+        let x := C'.getCentralVertex μ (C'.getCentralVertex_condition hstop hbig)
+        have hx : x ∈ C'.X := BookConfig.getCentralVertex_mem_x _ _ _
+        have hlt : ((blue_neighbors χ) x ∩ C'.X).card < C'.X.card := by
+          refine card_lt_card ?_
+          exact (ssubset_iff_of_subset inter_subset_right).2
+            ⟨x, hx, by simp [not_mem_colNeighbors]⟩
+        have hcard : (C'.densityBoostStepBasic x hx).X.card + 1 ≤ C'.X.card := by
+          rw [BookConfig.densityBoostStepBasic_x]
+          omega
+        have hdiv : (i + 1) / 2 = i / 2 + 1 := by
+          obtain ⟨r, rfl⟩ := Nat.not_even_iff_odd.mp heven
+          omega
+        rw [BookConfig.densityBoostStepBasic_x]
+        dsimp only [x] at hlt hcard
+        omega
 
 theorem algorithmOption_terminates (μ : ℝ) (ini : BookConfig χ) (hk : k ≠ 0) (hl : l ≠ 0) :
     ∃ i, algorithmOption μ k l ini (i + 1) = none := by
@@ -764,12 +826,33 @@ theorem some_algorithm_of_finalStep_le (hi : i ≤ finalStep μ k l ini) :
 theorem condition_fails_at_end (hk : k ≠ 0) (hl : l ≠ 0) :
     (endState μ k l ini).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨
       (endState μ k l ini).p ≤ 1 / k := by
-  sorry
+  have hnone := finalStep_is_none (μ := μ) (k := k) (l := l) (ini := ini) hk hl
+  have hsome :
+      algorithmOption μ k l ini (finalStep μ k l ini) = some (endState μ k l ini) := by
+    rw [← some_algorithm_of_finalStep_le (μ := μ) (k := k) (l := l) (ini := ini) le_rfl]
+    rfl
+  by_cases h :
+      (endState μ k l ini).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨
+        (endState μ k l ini).p ≤ 1 / k
+  · exact h
+  · exfalso
+    unfold algorithmOption at hnone
+    rw [hsome] at hnone
+    simp only at hnone
+    rw [dif_neg h] at hnone
+    simp at hnone
 
 theorem succeed_of_finalStep_le' (hi : i < finalStep μ k l ini) :
     ¬((algorithm μ k l ini i).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨
         (algorithm μ k l ini i).p ≤ 1 / k) := by
-  sorry
+  intro h
+  have hnone : algorithmOption μ k l ini (i + 1) = none := by
+    unfold algorithmOption
+    rw [← some_algorithm_of_finalStep_le (μ := μ) (k := k) (l := l) (ini := ini) hi.le]
+    simp only
+    rw [dif_pos h]
+  have hle : finalStep μ k l ini ≤ i := Nat.sInf_le hnone
+  omega
 
 theorem ramseyNumber_lt_of_lt_finalStep (hi : i < finalStep μ k l ini) :
     ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] < (algorithm μ k l ini i).X.card :=
@@ -799,7 +882,13 @@ theorem algorithm_succ (hi : i < finalStep μ k l ini) :
                 (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y) then
             C.redStepBasic x (C.getCentralVertex_mem_x _ _)
           else C.densityBoostStepBasic x (C.getCentralVertex_mem_x _ _) := by
-  sorry
+  apply Option.some.inj
+  rw [some_algorithm_of_finalStep_le (μ := μ) (k := k) (l := l) (ini := ini)
+    (Nat.succ_le_of_lt hi)]
+  unfold algorithmOption
+  rw [← some_algorithm_of_finalStep_le (μ := μ) (k := k) (l := l) (ini := ini) hi.le]
+  simp only
+  rw [dif_neg (succeed_of_finalStep_le' hi)]
 
 /-- The set of degree regularisation steps. Note this is indexed differently than the paper. -/
 noncomputable def degreeSteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Finset ℕ :=

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -266,7 +266,15 @@ def redStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ
     rw [coe_insert, TopEdgeLabelling.monochromaticOf_insert this, and_iff_right C.red_a]
     intro a ha
     exact C.red_XYA (Or.inl (by exact_mod_cast hx)) ha _
-  red_XYA := sorry
+  red_XYA := by
+    intro a ha b hb h
+    push_cast at ha hb
+    obtain ha_left | ha_right := Finset.mem_union.mp (by exact_mod_cast ha) <;>
+      obtain rfl | hb_in := Finset.mem_insert.mp (by exact_mod_cast hb)
+    · exact (mem_colNeighbors'.mp (Finset.mem_inter.mp ha_left).1).choose_spec ▸ rfl
+    · exact C.red_XYA (Or.inl (Finset.mem_inter.mp ha_left).2) hb_in h
+    · exact (mem_colNeighbors'.mp (Finset.mem_inter.mp ha_right).1).choose_spec ▸ rfl
+    · exact C.red_XYA (Or.inr (Finset.mem_inter.mp ha_right).2) hb_in h
   blue_b := C.blue_b
   blue_XB := C.blue_XB.subset_left (Finset.coe_subset.2 inter_subset_right)
 
@@ -565,10 +573,13 @@ theorem get_book_condition {μ : ℝ} {k l : ℕ} {C : BookConfig χ} (hk : k �
   by
   rw [← filter_nonempty_iff, ← card_pos]
   refine' hX.trans_lt' _
-  rw [ramseyNumber_pos]
-  rw [Fin.forall_fin_two]
+  rw [ramseyNumber_pos, Fin.forall_fin_two]
   simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
-  sorry
+  exact ⟨hk, fun h => by
+    have h0 : (l:ℝ) ^ (2/3:ℝ) ≤ 0 := Nat.ceil_eq_zero.mp h
+    have h1 : 0 < (l:ℝ) := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hl)
+    have h2 : 0 < (l:ℝ) ^ (2/3:ℝ) := Real.rpow_pos_of_pos h1 _
+    linarith⟩
 
 end
 
@@ -628,7 +639,25 @@ theorem getCentralVertex_condition {μ : ℝ} {k l : ℕ} (C : BookConfig χ)
     (h : ¬(C.X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨ C.p ≤ 1 / k))
     (h' : ¬ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ numBigBlues μ C) :
     ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card := by
-  sorry
+  have h₁ : ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] < C.X.card :=
+    not_le.mp (not_or.mp h).1
+  have h₂ : numBigBlues μ C < ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] :=
+    not_le.mp h'
+  have hrpow : (l : ℝ) ^ (2 / 3 : ℝ) ≤ (l : ℝ) ^ (3 / 4 : ℝ) := by
+    by_cases hl : 1 ≤ l
+    · exact Real.rpow_le_rpow_of_exponent_le (by exact_mod_cast hl) (by norm_num)
+    · push_neg at hl; interval_cases l <;> norm_num
+  have hceil : ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊ ≤ ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊ :=
+    Nat.ceil_le.2 (hrpow.trans (Nat.le_ceil _))
+  have hle : numBigBlues μ C < C.X.card :=
+    h₂.trans_le ((ramseyNumber.mono_two le_rfl hceil).trans h₁.le)
+  by_contra hall
+  push_neg at hall
+  have key : (C.X.filter fun x => μ * C.X.card ≤ ((blue_neighbors χ) x ∩ C.X).card) = C.X :=
+    Finset.filter_true_of_mem (fun x hx => le_of_lt (hall x hx))
+  have : C.X.card ≤ numBigBlues μ C := by
+    rw [numBigBlues, key]
+  omega
 
 end
 

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -207,15 +207,15 @@ open TopEdgeLabelling
 properties which are needed for it
 -/
 structure BookConfig (χ : TopEdgeLabelling V (Fin 2)) where
-  (X y A B : Finset V)
-  hXY : Disjoint X y
+  (X Y A B : Finset V)
+  hXY : Disjoint X Y
   hXA : Disjoint X A
   hXB : Disjoint X B
-  hYA : Disjoint y A
-  hYB : Disjoint y B
+  hYA : Disjoint Y A
+  hYB : Disjoint Y B
   hAB : Disjoint A B
   red_a : χ.MonochromaticOf A 0
-  red_XYA : χ.MonochromaticBetween (X ∪ y) A 0
+  red_XYA : χ.MonochromaticBetween (X ∪ Y) A 0
   blue_b : χ.MonochromaticOf B 1
   blue_XB : χ.MonochromaticBetween X B 1
 
@@ -223,7 +223,7 @@ namespace BookConfig
 
 /-- Define `p` from the paper at a given configuration. -/
 def p (C : BookConfig χ) : ℝ :=
-  (red_density χ) C.X C.y
+  (red_density χ) C.X C.Y
 
 section
 
@@ -242,20 +242,20 @@ instance : Inhabited (BookConfig χ) :=
 /-- Take a red step for the book algorithm, given `x ∈ X`. -/
 def redStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ where
   X := (red_neighbors χ) x ∩ C.X
-  y := (red_neighbors χ) x ∩ C.y
+  Y := (red_neighbors χ) x ∩ C.Y
   A := insert x C.A
   B := C.B
-  hXY := disjoint_of_subset_left (inter_subset_right) (C.hXY.inf_right' _)
+  hXY := disjoint_of_subset_left inter_subset_right (C.hXY.inf_right' _)
   hXA := by
     rw [disjoint_insert_right, mem_inter, not_and_or]
     refine' ⟨Or.inl not_mem_colNeighbors, _⟩
-    exact disjoint_of_subset_left (inter_subset_right) C.hXA
-  hXB := disjoint_of_subset_left (inter_subset_right) C.hXB
+    exact disjoint_of_subset_left inter_subset_right C.hXA
+  hXB := disjoint_of_subset_left inter_subset_right C.hXB
   hYA := by
     rw [disjoint_insert_right, mem_inter, not_and_or]
     refine' ⟨Or.inl not_mem_colNeighbors, _⟩
-    exact disjoint_of_subset_left (inter_subset_right) C.hYA
-  hYB := disjoint_of_subset_left (inter_subset_right) C.hYB
+    exact disjoint_of_subset_left inter_subset_right C.hYA
+  hYB := disjoint_of_subset_left inter_subset_right C.hYB
   hAB := by
     simp only [disjoint_insert_left, C.hAB, and_true]
     exact Finset.disjoint_left.1 C.hXB hx
@@ -265,6 +265,7 @@ def redStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ wh
     intro a ha
     exact C.red_XYA (Or.inl (by exact_mod_cast hx)) ha _
   red_XYA := by
+    -- TODO: find a cleaner proof closer to the original
     intro a ha b hb h
     push_cast at ha hb
     obtain ha_left | ha_right := Finset.mem_union.mp (by exact_mod_cast ha) <;>
@@ -278,18 +279,18 @@ def redStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ wh
 
 theorem redStepBasic_x {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (redStepBasic C x hx).X = (red_neighbors χ) x ∩ C.X :=
-  by simp [redStepBasic]
+  rfl
 
-theorem redStepBasic_y {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
-    (redStepBasic C x hx).y = (red_neighbors χ) x ∩ C.y :=
-  by simp [redStepBasic]
+theorem redStepBasic_Y {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
+    (redStepBasic C x hx).Y = (red_neighbors χ) x ∩ C.Y :=
+  rfl
 
 theorem redStepBasic_a {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (redStepBasic C x hx).A = insert x C.A :=
-  by simp [redStepBasic]
+  rfl
 
 theorem redStepBasic_b {C : BookConfig χ} {x : V} (hx : x ∈ C.X) : (redStepBasic C x hx).B = C.B :=
-  by simp [redStepBasic]
+  rfl
 
 end
 
@@ -300,7 +301,7 @@ def bigBlueStepBasic (C : BookConfig χ) (S T : Finset V) (hS : S ⊆ C.X) (hT :
     (hSS : χ.MonochromaticOf S 1) (hST : Disjoint S T) (hST' : χ.MonochromaticBetween S T 1) :
     BookConfig χ where
   X := T
-  y := C.y
+  Y := C.Y
   A := C.A
   B := C.B ∪ S
   hXY := disjoint_of_subset_left hT C.hXY
@@ -310,12 +311,7 @@ def bigBlueStepBasic (C : BookConfig χ) (S T : Finset V) (hS : S ⊆ C.X) (hT :
   hYB := disjoint_union_right.2 ⟨C.hYB, disjoint_of_subset_right hS C.hXY.symm⟩
   hAB := disjoint_union_right.2 ⟨C.hAB, disjoint_of_subset_right hS C.hXA.symm⟩
   red_a := C.red_a
-  red_XYA := C.red_XYA.subset_left (by
-    intro a ha
-    simp only [Set.mem_union] at ha
-    obtain ha | ha := ha
-    · exact Set.mem_union_left _ (Finset.coe_subset.2 hT ha)
-    · exact Set.mem_union_right _ ha)
+  red_XYA := C.red_XYA.subset_left (by grind)
   blue_b := by
     rw [coe_union, EdgeLabelling.monochromaticOf_union]
     exact ⟨C.blue_b, hSS, C.blue_XB.symm.subset_right hS⟩
@@ -328,7 +324,7 @@ variable [Fintype V]
 /-- Take a density boost step for the book algorithm, given `x ∈ X`. -/
 def densityBoostStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ where
   X := (blue_neighbors χ) x ∩ C.X
-  y := (red_neighbors χ) x ∩ C.y
+  Y := (red_neighbors χ) x ∩ C.Y
   A := C.A
   B := insert x C.B
   hXY := (C.hXY.inf_left' _).inf_right' _
@@ -360,14 +356,14 @@ def densityBoostStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookCon
       EdgeLabelling.monochromaticBetween_union_right,
       EdgeLabelling.monochromaticBetween_singleton_right]
     refine' ⟨_, C.blue_XB.subset_left (Finset.coe_subset.2 inter_subset_right)⟩
-    simp (config := { contextual := true }) [mem_colNeighbors']
+    simp +contextual [mem_colNeighbors']
 
 theorem densityBoostStepBasic_x {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (densityBoostStepBasic C x hx).X = (blue_neighbors χ) x ∩ C.X :=
   by simp [densityBoostStepBasic]
 
-theorem densityBoostStepBasic_y {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
-    (densityBoostStepBasic C x hx).y = (red_neighbors χ) x ∩ C.y :=
+theorem densityBoostStepBasic_Y {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
+    (densityBoostStepBasic C x hx).Y = (red_neighbors χ) x ∩ C.Y :=
   by simp [densityBoostStepBasic]
 
 theorem densityBoostStepBasic_a {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
@@ -387,7 +383,7 @@ to keep in `X`. -/
 def degreeRegularisationStepBasic (C : BookConfig χ) (U : Finset V) (h : U ⊆ C.X) : BookConfig χ
     where
   X := U
-  y := C.y
+  Y := C.Y
   A := C.A
   B := C.B
   hXY := C.hXY.mono_left h
@@ -397,12 +393,7 @@ def degreeRegularisationStepBasic (C : BookConfig χ) (U : Finset V) (h : U ⊆ 
   hYB := C.hYB
   hAB := C.hAB
   red_a := C.red_a
-  red_XYA := C.red_XYA.subset_left (by
-    intro a ha
-    simp only [Set.mem_union] at ha
-    obtain ha | ha := ha
-    · exact Set.mem_union_left _ (Finset.coe_subset.2 h ha)
-    · exact Set.mem_union_right _ ha)
+  red_XYA := C.red_XYA.subset_left (by grind)
   blue_b := C.blue_b
   blue_XB := C.blue_XB.subset_left (Finset.coe_subset.2 h)
 
@@ -412,28 +403,28 @@ variable [Fintype V]
 noncomputable def degreeRegularisationStep (k : ℕ) (p₀ : ℝ) (C : BookConfig χ) : BookConfig χ :=
   degreeRegularisationStepBasic C
     (C.X.filter fun x =>
-      (C.p - k ^ (1 / 8 : ℝ) * αFunction k (height k p₀ C.p)) * C.y.card ≤
-        ((red_neighbors χ) x ∩ C.y).card)
+      (C.p - k ^ (1 / 8 : ℝ) * αFunction k (height k p₀ C.p)) * C.Y.card ≤
+        ((red_neighbors χ) x ∩ C.Y).card)
     (filter_subset _ _)
 
 theorem degreeRegularisationStep_x {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
     (degreeRegularisationStep k p₀ C).X =
       C.X.filter fun x =>
-        (C.p - k ^ (1 / 8 : ℝ) * αFunction k (height k p₀ C.p)) * C.y.card ≤
-          ((red_neighbors χ) x ∩ C.y).card :=
-  by simp [degreeRegularisationStep, degreeRegularisationStepBasic]
+        (C.p - k ^ (1 / 8 : ℝ) * αFunction k (height k p₀ C.p)) * C.Y.card ≤
+          ((red_neighbors χ) x ∩ C.Y).card :=
+  rfl
 
-theorem degreeRegularisationStep_y {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
-    (degreeRegularisationStep k p₀ C).y = C.y :=
-  by simp [degreeRegularisationStep, degreeRegularisationStepBasic]
+theorem degreeRegularisationStep_Y {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
+    (degreeRegularisationStep k p₀ C).Y = C.Y :=
+  rfl
 
 theorem degreeRegularisationStep_a {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
     (degreeRegularisationStep k p₀ C).A = C.A :=
-  by simp [degreeRegularisationStep, degreeRegularisationStepBasic]
+  rfl
 
 theorem degreeRegularisationStep_b {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
     (degreeRegularisationStep k p₀ C).B = C.B :=
-  by simp [degreeRegularisationStep, degreeRegularisationStepBasic]
+  rfl
 
 theorem degreeRegularisationStep_x_subset {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
     (degreeRegularisationStep k p₀ C).X ⊆ C.X := by
@@ -579,11 +570,7 @@ theorem get_book_condition {μ : ℝ} {k l : ℕ} {C : BookConfig χ} (hk : k �
   refine' hX.trans_lt' _
   rw [ramseyNumber_pos, Fin.forall_fin_two]
   simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
-  exact ⟨hk, fun h => by
-    have h0 : (l:ℝ) ^ (2/3:ℝ) ≤ 0 := Nat.ceil_eq_zero.mp h
-    have h1 : 0 < (l:ℝ) := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hl)
-    have h2 : 0 < (l:ℝ) ^ (2/3:ℝ) := Real.rpow_pos_of_pos h1 _
-    linarith⟩
+  exact ⟨hk, by positivity⟩
 
 end
 
@@ -595,7 +582,7 @@ noncomputable def bigBlueStep (μ : ℝ) (C : BookConfig χ) : BookConfig χ :=
 theorem bigBlueStep_x {μ : ℝ} {C : BookConfig χ} : (bigBlueStep μ C).X = (getBook χ μ C.X).2 :=
   by simp [bigBlueStep, bigBlueStepBasic]
 
-theorem bigBlueStep_y {μ : ℝ} {C : BookConfig χ} : (bigBlueStep μ C).y = C.y :=
+theorem bigBlueStep_Y {μ : ℝ} {C : BookConfig χ} : (bigBlueStep μ C).Y = C.Y :=
   by simp [bigBlueStep, bigBlueStepBasic]
 
 theorem bigBlueStep_a {μ : ℝ} {C : BookConfig χ} : (bigBlueStep μ C).A = C.A :=
@@ -615,7 +602,7 @@ noncomputable def centralVertices (μ : ℝ) (C : BookConfig χ) : Finset V :=
 
 theorem exists_central_vertex (μ : ℝ) (C : BookConfig χ)
     (hX : ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card) :
-    ∃ x ∈ centralVertices μ C, ∀ y ∈ centralVertices μ C, weight χ C.X C.y y ≤ weight χ C.X C.y x :=
+    ∃ x ∈ centralVertices μ C, ∀ y ∈ centralVertices μ C, weight χ C.X C.Y y ≤ weight χ C.X C.Y x :=
   exists_max_image _ _ (by rwa [centralVertices, filter_nonempty_iff])
 
 /-- Get the central vertex as in step 3. -/
@@ -636,7 +623,7 @@ theorem getCentralVertex_mem_x (μ : ℝ) (C : BookConfig χ)
 theorem getCentralVertex_max (μ : ℝ) (C : BookConfig χ)
     (hX : ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card) (y : V)
     (hy : y ∈ centralVertices μ C) :
-    weight χ C.X C.y y ≤ weight χ C.X C.y (getCentralVertex μ C hX) :=
+    weight χ C.X C.Y y ≤ weight χ C.X C.Y (getCentralVertex μ C hX) :=
   (exists_central_vertex μ C hX).choose_spec.2 _ hy
 
 theorem getCentralVertex_condition {μ : ℝ} {k l : ℕ} (C : BookConfig χ)
@@ -687,7 +674,7 @@ noncomputable def algorithmOption (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) :
               let x := C.getCentralVertex μ (C.getCentralVertex_condition h h')
               if
                   C.p - αFunction k (height k ini.p C.p) ≤
-                    (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y) then
+                    (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.Y) then
                 C.redStepBasic x (C.getCentralVertex_mem_x _ _)
               else C.densityBoostStepBasic x (C.getCentralVertex_mem_x _ _)
 
@@ -715,62 +702,39 @@ theorem algorithmOption_x_weak_bound {i : ℕ} (C : BookConfig χ) (hk : k ≠ 0
       simp
   | succ i ih =>
       obtain ⟨C', hC'⟩ := algorithmOption_is_some_of ⟨C, hC⟩
-      have ih' := ih C' hC'
       unfold algorithmOption at hC
       rw [hC'] at hC
       simp only at hC
       split_ifs at hC with hstop heven hbig hred
-      · injection hC with hC
-        subst C
-        have hcard : (C'.degreeRegularisationStep k ini.p).X.card ≤ C'.X.card :=
+      · injection hC with hC; subst C
+        have : (C'.degreeRegularisationStep k ini.p).X.card ≤ C'.X.card :=
           card_le_card BookConfig.degreeRegularisationStep_x_subset
-        have hdiv : (i + 1) / 2 = i / 2 := by
-          obtain ⟨r, rfl⟩ := heven
-          omega
-        omega
-      · injection hC with hC
-        subst C
-        have hcard : (C'.bigBlueStep μ).X.card + 1 ≤ C'.X.card := by
+        grind
+      · injection hC with hC; subst C
+        have : (C'.bigBlueStep μ).X.card + 1 ≤ C'.X.card := by
           rw [BookConfig.bigBlueStep_x]
           exact BookConfig.getBook_snd_card_le_X (BookConfig.get_book_condition hk hl hbig)
-        have hdiv : (i + 1) / 2 = i / 2 + 1 := by
-          obtain ⟨r, rfl⟩ := Nat.not_even_iff_odd.mp heven
-          omega
-        omega
-      · injection hC with hC
-        subst C
+        grind
+      · injection hC with hC; subst C
         let x := C'.getCentralVertex μ (C'.getCentralVertex_condition hstop hbig)
         have hx : x ∈ C'.X := BookConfig.getCentralVertex_mem_x _ _ _
-        have hlt : ((red_neighbors χ) x ∩ C'.X).card < C'.X.card := by
+        have : ((red_neighbors χ) x ∩ C'.X).card < C'.X.card := by
           refine card_lt_card ?_
           exact (ssubset_iff_of_subset inter_subset_right).2
-            ⟨x, hx, by simp [not_mem_colNeighbors]⟩
-        have hcard : (C'.redStepBasic x hx).X.card + 1 ≤ C'.X.card := by
-          rw [BookConfig.redStepBasic_x]
-          omega
-        have hdiv : (i + 1) / 2 = i / 2 + 1 := by
-          obtain ⟨r, rfl⟩ := Nat.not_even_iff_odd.mp heven
-          omega
-        rw [BookConfig.redStepBasic_x]
-        dsimp only [x] at hlt hcard
-        omega
-      · injection hC with hC
-        subst C
+            ⟨_, hx, by simp [not_mem_colNeighbors]⟩
+        have : (C'.redStepBasic x hx).X.card + 1 ≤ C'.X.card := by
+          rw [BookConfig.redStepBasic_x]; grind
+        grind
+      · injection hC with hC; subst C
         let x := C'.getCentralVertex μ (C'.getCentralVertex_condition hstop hbig)
         have hx : x ∈ C'.X := BookConfig.getCentralVertex_mem_x _ _ _
-        have hlt : ((blue_neighbors χ) x ∩ C'.X).card < C'.X.card := by
+        have : ((blue_neighbors χ) x ∩ C'.X).card < C'.X.card := by
           refine card_lt_card ?_
           exact (ssubset_iff_of_subset inter_subset_right).2
-            ⟨x, hx, by simp [not_mem_colNeighbors]⟩
-        have hcard : (C'.densityBoostStepBasic x hx).X.card + 1 ≤ C'.X.card := by
-          rw [BookConfig.densityBoostStepBasic_x]
-          omega
-        have hdiv : (i + 1) / 2 = i / 2 + 1 := by
-          obtain ⟨r, rfl⟩ := Nat.not_even_iff_odd.mp heven
-          omega
-        rw [BookConfig.densityBoostStepBasic_x]
-        dsimp only [x] at hlt hcard
-        omega
+            ⟨_, hx, by simp [not_mem_colNeighbors]⟩
+        have : (C'.densityBoostStepBasic x hx).X.card + 1 ≤ C'.X.card := by
+          rw [BookConfig.densityBoostStepBasic_x]; grind
+        grind
 
 theorem algorithmOption_terminates (μ : ℝ) (ini : BookConfig χ) (hk : k ≠ 0) (hl : l ≠ 0) :
     ∃ i, algorithmOption μ k l ini (i + 1) = none := by
@@ -882,7 +846,7 @@ theorem algorithm_succ (hi : i < finalStep μ k l ini) :
             C.getCentralVertex μ (C.getCentralVertex_condition (succeed_of_finalStep_le' hi) h')
           if
               C.p - αFunction k (height k ini.p C.p) ≤
-                (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y) then
+                (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.Y) then
             C.redStepBasic x (C.getCentralVertex_mem_x _ _)
           else C.densityBoostStepBasic x (C.getCentralVertex_mem_x _ _) := by
   apply Option.some.inj
@@ -954,7 +918,7 @@ noncomputable def redSteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Finset
       let x := getX i.2
       let C := algorithm μ k l ini i
       C.p - αFunction k (height k ini.p C.p) ≤
-        (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y)
+        (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.Y)
 
 /-- The set of density boost steps. -/
 noncomputable def densitySteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Finset ℕ :=
@@ -962,7 +926,7 @@ noncomputable def densitySteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Fi
     (redOrDensitySteps μ k l ini).attach.filter fun i =>
       let x := getX i.2
       let C := algorithm μ k l ini i
-      (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y) <
+      (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.Y) <
         C.p - αFunction k (height k ini.p C.p)
 
 theorem redSteps_subset_redOrDensitySteps : redSteps μ k l ini ⊆ redOrDensitySteps μ k l ini :=
@@ -1122,15 +1086,15 @@ theorem x_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
 
 -- (7)
 theorem y_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
-    (algorithm μ k l ini (i + 1)).y ⊆ (algorithm μ k l ini i).y :=
+    (algorithm μ k l ini (i + 1)).Y ⊆ (algorithm μ k l ini i).Y :=
   by
   rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
-  · rw [red_applied hi', BookConfig.redStepBasic_y]
+  · rw [red_applied hi', BookConfig.redStepBasic_Y]
     exact inter_subset_right
-  · rw [big_blue_applied hi', BookConfig.bigBlueStep_y]
-  · rw [density_applied hi', BookConfig.densityBoostStepBasic_y]
+  · rw [big_blue_applied hi', BookConfig.bigBlueStep_Y]
+  · rw [density_applied hi', BookConfig.densityBoostStepBasic_Y]
     exact inter_subset_right
-  · rw [degree_regularisation_applied hi', BookConfig.degreeRegularisationStep_y]
+  · rw [degree_regularisation_applied hi', BookConfig.degreeRegularisationStep_Y]
 
 theorem a_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
     (algorithm μ k l ini i).A ⊆ (algorithm μ k l ini (i + 1)).A :=

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -102,8 +102,7 @@ theorem interedges_card_eq_sum {V : Type*} [DecidableEq V] [Fintype V] {G : Simp
     singleton_product, filter_map, card_map, inter_comm, ← filter_mem_eq_inter]
   congr 1
   refine' filter_congr _
-  simp only [Function.Embedding.coeFn_mk, mem_neighborFinset]
-  exact fun _ _ => Iff.rfl
+  simp only [Function.Embedding.coeFn_mk, Function.comp_apply, mem_neighborFinset, implies_true]
 
 theorem colDensity_eq_sum {K : Type*} [Fintype V] [DecidableEq K] {χ : TopEdgeLabelling V K}
     {k : K} {A B : Finset V} :

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -6,7 +6,6 @@ Authors: Bhavik Mehta
 import ExponentialRamsey.Prereq.Ramsey
 import ExponentialRamsey.Prereq.GraphProbability
 import Mathlib.Combinatorics.SimpleGraph.Density
-import Data.Seq.Seq
 
 /-!
 # Book algorithm
@@ -25,7 +24,7 @@ variable {V K : Type*}
 
 theorem cast_card_sdiff {α R : Type*} [AddGroupWithOne R] [DecidableEq α] {s t : Finset α}
     (h : s ⊆ t) : ((t \ s).card : R) = t.card - s.card := by
-  rw [card_sdiff h, Nat.cast_sub (card_le_of_subset h)]
+  rw [card_sdiff_of_subset h, Nat.cast_sub (card_le_card h)]
 
 /-- For `χ` a labelling and vertex sets `X` `Y` and a label `k`, give the edge density of
 `k`-labelled edges between `X` and `Y`. -/
@@ -35,7 +34,7 @@ def colDensity [DecidableEq V] [DecidableEq K] (χ : TopEdgeLabelling V K) (k : 
 
 theorem colDensity_comm [DecidableEq V] [DecidableEq K] (χ : TopEdgeLabelling V K) (k : K)
     (X Y : Finset V) : colDensity χ k X Y = colDensity χ k Y X := by
-  rw [col_density, edge_density_comm, col_density]
+  rw [colDensity, edgeDensity_comm, colDensity]
 
 theorem colDensity_nonneg [DecidableEq V] [DecidableEq K] {χ : TopEdgeLabelling V K} {k : K}
     {X Y : Finset V} : 0 ≤ colDensity χ k X Y :=
@@ -45,15 +44,15 @@ theorem colDensity_le_one [DecidableEq V] [DecidableEq K] {χ : TopEdgeLabelling
     {X Y : Finset V} : colDensity χ k X Y ≤ 1 :=
   by
   rw [← Rat.cast_one]
-  exact Rat.cast_le.2 (edge_density_le_one _ _ _)
+  exact Rat.cast_le.2 (edgeDensity_le_one _ _ _)
 
 theorem colDensity_empty_left [DecidableEq V] [DecidableEq K] {χ : TopEdgeLabelling V K} {k : K}
     {Y : Finset V} : colDensity χ k ∅ Y = 0 := by
-  rw [col_density, edge_density_empty_left, Rat.cast_zero]
+  rw [colDensity, edgeDensity_empty_left, Rat.cast_zero]
 
 theorem colDensity_empty_right [DecidableEq V] [DecidableEq K] {χ : TopEdgeLabelling V K} {k : K}
     {X : Finset V} : colDensity χ k X ∅ = 0 := by
-  rw [col_density, edge_density_empty_right, Rat.cast_zero]
+  rw [colDensity, edgeDensity_empty_right, Rat.cast_zero]
 
 scoped[ExponentialRamsey] notation "red_density" χ:1024 => SimpleGraph.colDensity χ 0
 
@@ -77,25 +76,25 @@ section
 variable [Fintype V]
 
 theorem mem_colNeighbors [DecidableEq K] {χ : TopEdgeLabelling V K} {x y : V} {k : K} :
-    y ∈ colNeighbors χ k x ↔ ∃ H : x ≠ y, χ.get x y = k := by
-  rw [col_neighbors, mem_neighborFinset, TopEdgeLabelling.labelGraph_adj]
+    y ∈ colNeighbors χ k x ↔ ∃ H : x ≠ y, χ.get x y H = k := by
+  rw [colNeighbors, mem_neighborFinset, TopEdgeLabelling.labelGraph_adj]
 
-theorem mem_col_neighbors' [DecidableEq K] {χ : TopEdgeLabelling V K} {x y : V} {k : K} :
-    y ∈ colNeighbors χ k x ↔ ∃ H : y ≠ x, χ.get y x = k := by
-  rw [col_neighbors, mem_neighborFinset, adj_comm, TopEdgeLabelling.labelGraph_adj]
+theorem mem_colNeighbors' [DecidableEq K] {χ : TopEdgeLabelling V K} {x y : V} {k : K} :
+    y ∈ colNeighbors χ k x ↔ ∃ H : y ≠ x, χ.get y x H = k := by
+  rw [colNeighbors, mem_neighborFinset, adj_comm, TopEdgeLabelling.labelGraph_adj]
 
 theorem mem_colNeighbors_comm [DecidableEq K] {χ : TopEdgeLabelling V K} {x y : V} {k : K} :
-    y ∈ colNeighbors χ k x ↔ x ∈ colNeighbors χ k y := by rw [mem_col_neighbors, mem_col_neighbors']
+    y ∈ colNeighbors χ k x ↔ x ∈ colNeighbors χ k y := by rw [mem_colNeighbors, mem_colNeighbors']
 
 theorem not_mem_colNeighbors [DecidableEq K] {χ : TopEdgeLabelling V K} {x : V} {k : K} :
     x ∉ colNeighbors χ k x :=
-  not_mem_neighborFinset_self _ _
+  notMem_neighborFinset_self _ _
 
 end
 
 theorem interedges_card_eq_sum {V : Type*} [DecidableEq V] [Fintype V] {G : SimpleGraph V}
     [DecidableRel G.Adj] {A B : Finset V} :
-    (G.interedges A B).card = ∑ x in A, (G.neighborFinset x ∩ B).card :=
+    (G.interedges A B).card = ∑ x ∈ A, (G.neighborFinset x ∩ B).card :=
   by
   have : ∀ e ∈ G.interedges A B, Prod.fst e ∈ A :=
     by
@@ -106,19 +105,20 @@ theorem interedges_card_eq_sum {V : Type*} [DecidableEq V] [Fintype V] {G : Simp
   refine' sum_congr rfl _
   intro x hx
   rw [interedges, Rel.interedges, filter_filter]
-  simp only [and_comm']
+  simp only [and_comm]
   rw [← filter_filter, filter_product_left fun i => i = x, Finset.filter_eq', if_pos hx,
     singleton_product, filter_map, card_map, inter_comm, ← filter_mem_eq_inter]
   congr 1
   refine' filter_congr _
-  simp only [Function.Embedding.coeFn_mk, mem_neighborFinset, iff_self_iff, imp_true_iff]
+  simp only [Function.Embedding.coeFn_mk, mem_neighborFinset]
+  exact fun _ _ => Iff.rfl
 
 theorem colDensity_eq_sum {K : Type*} [Fintype V] [DecidableEq K] {χ : TopEdgeLabelling V K}
     {k : K} {A B : Finset V} :
-    colDensity χ k A B = (∑ x in A, (colNeighbors χ k x ∩ B).card) / (A.card * B.card) :=
+    colDensity χ k A B = (∑ x ∈ A, (colNeighbors χ k x ∩ B).card) / (A.card * B.card) :=
   by
-  rw [col_density, edge_density_def, interedges_card_eq_sum]
-  simp only [Nat.cast_sum, Rat.cast_div, Rat.cast_sum, Rat.cast_coe_nat, Rat.cast_mul]
+  rw [colDensity, edgeDensity_def, interedges_card_eq_sum]
+  simp only [Nat.cast_sum, Rat.cast_div, Rat.cast_sum, Rat.cast_natCast, Rat.cast_mul]
   rfl
 
 section
@@ -128,16 +128,16 @@ variable [Fintype V]
 /-- Define the weight of an ordered pair for the book algorithm.
 `pair_weight χ X Y x y` corresponds to `ω(x, y)` in the paper, see equation (3).
 -/
-noncomputable def pairWeight (χ : TopEdgeLabelling V (Fin 2)) (X Y : Finset V) (x y : V) : ℝ :=
-  Y.card⁻¹ *
+noncomputable def pairWeight [DecidableEq (Fin 2)] (χ : TopEdgeLabelling V (Fin 2)) (X Y : Finset V) (x y : V) : ℝ :=
+  (Y.card : ℝ)⁻¹ *
     (((red_neighbors χ) x ∩ (red_neighbors χ) y ∩ Y).card -
       (red_density χ) X Y * ((red_neighbors χ) x ∩ Y).card)
 
 /-- Define the weight of a vertex for the book algorithm.
 `pair_weight χ X Y x` corresponds to `ω(x)` in the paper, see equation (4).
 -/
-noncomputable def weight (χ : TopEdgeLabelling V (Fin 2)) (X Y : Finset V) (x : V) : ℝ :=
-  ∑ y in X.eraseₓ x, pairWeight χ X Y x y
+noncomputable def weight [DecidableEq (Fin 2)] (χ : TopEdgeLabelling V (Fin 2)) (X Y : Finset V) (x : V) : ℝ :=
+  ∑ y ∈ X.erase x, pairWeight χ X Y x y
 
 end
 
@@ -146,26 +146,26 @@ noncomputable def qFunction (k : ℕ) (p₀ : ℝ) (h : ℕ) : ℝ :=
   p₀ + ((1 + k ^ (-1 / 4 : ℝ)) ^ h - 1) / k
 
 theorem qFunction_zero {k : ℕ} {p₀ : ℝ} : qFunction k p₀ 0 = p₀ := by
-  rw [q_function, pow_zero, sub_self, zero_div, add_zero]
+  rw [qFunction, pow_zero, sub_self, zero_div, add_zero]
 
 theorem qFunction_one {k : ℕ} {p₀ : ℝ} : qFunction k p₀ 1 = p₀ + k ^ (-1 / 4 : ℝ) / k := by
-  rw [q_function, pow_one, add_sub_cancel']
+  rw [qFunction, pow_one, add_sub_cancel_left]
 
-theorem q_increasing {k h₁ h₂ : ℕ} {p₀ : ℝ} (h : h₁ ≤ h₂) : qFunction k p₀ h₁ ≤ qFunction k p₀ h₂ :=
-  by
-  rw [q_function, q_function, add_le_add_iff_left]
-  refine' div_le_div_of_le (Nat.cast_nonneg _) (sub_le_sub_right (pow_le_pow _ h) _)
-  rw [le_add_iff_nonneg_right]
-  exact rpow_nonneg_of_nonneg (Nat.cast_nonneg _) _
+theorem q_increasing {k h₁ h₂ : ℕ} {p₀ : ℝ} (h : h₁ ≤ h₂) : qFunction k p₀ h₁ ≤ qFunction k p₀ h₂ := by
+  simp only [qFunction, add_le_add_iff_left]
+  cases k
+  · simp
+  · rw [div_le_div_iff_of_pos_right (by positivity)]
+    exact sub_le_sub_right (pow_le_pow_right₀ (le_add_of_nonneg_right (Real.rpow_nonneg (Nat.cast_nonneg _) _)) h) 1
 
 theorem qFunction_weak_lower {k : ℕ} {p₀ : ℝ} {h : ℕ} :
     p₀ + h * k ^ (-1 / 4 : ℝ) / k ≤ qFunction k p₀ h :=
   by
-  rw [q_function, add_le_add_iff_left]
-  refine' div_le_div_of_le (Nat.cast_nonneg _) _
+  rw [qFunction, add_le_add_iff_left]
+  refine' div_le_div_of_nonneg_right _ (Nat.cast_nonneg _)
   refine' (sub_le_sub_right (one_add_mul_le_pow _ h) _).trans_eq' _
-  · exact (rpow_nonneg_of_nonneg (Nat.cast_nonneg _) _).trans' (by norm_num)
-  rw [add_sub_cancel']
+  · exact (Real.rpow_nonneg (Nat.cast_nonneg _) _).trans' (by norm_num)
+  rw [add_sub_cancel_left]
 
 -- The bound on h here is about k / ε, which is not good enough in general so I'm not gonna bother
 -- exposing it, later I show h ≤ 2 log k / ε works for suff large k, which is what's actually needed
@@ -173,8 +173,8 @@ theorem qFunction_above (p₀ c : ℝ) {k : ℕ} (hk : k ≠ 0) : ∃ h, 1 ≤ h
   by
   refine' ⟨max 1 ⌈(c - p₀) * k / k ^ (-1 / 4 : ℝ)⌉₊, le_max_left _ _, _⟩
   refine' (q_increasing (le_max_right _ _)).trans' _
-  refine' q_function_weak_lower.trans' _
-  rw [← sub_le_iff_le_add', mul_div_assoc, ← div_le_iff, div_div_eq_mul_div]
+  refine' qFunction_weak_lower.trans' _
+  rw [← sub_le_iff_le_add', mul_div_assoc, ← div_le_iff₀, div_div_eq_mul_div]
   · exact Nat.le_ceil _
   · positivity
 
@@ -186,18 +186,19 @@ theorem one_le_height {k : ℕ} {p₀ p : ℝ} : 1 ≤ height k p₀ p :=
   by
   rw [height]
   split_ifs with h
-  · exact (Nat.find_spec (q_function_above p₀ p h)).1
+  · exact (Nat.find_spec (qFunction_above p₀ p h)).1
   exact le_rfl
 
 /-- Define function `α_h` from the paper. We use the right half of equation (6) as the definition
-for simplicity, and `α_function_eq_q_diff` gives the left half. -/
+for simplicity, and `αFunction_eq_q_diff` gives the left half. -/
 noncomputable def αFunction (k : ℕ) (h : ℕ) : ℝ :=
   k ^ (-1 / 4 : ℝ) * (1 + k ^ (-1 / 4 : ℝ)) ^ (h - 1) / k
 
 theorem αFunction_eq_q_diff {k : ℕ} {p₀ : ℝ} {h : ℕ} :
     αFunction k (h + 1) = qFunction k p₀ (h + 1) - qFunction k p₀ h := by
-  rw [α_function, q_function, q_function, add_sub_add_left_eq_sub, div_sub_div_same,
-    sub_sub_sub_cancel_right, pow_succ, ← sub_one_mul, add_sub_cancel', Nat.add_sub_cancel]
+  simp only [αFunction, qFunction, add_sub_add_left_eq_sub, div_sub_div_same,
+    sub_sub_sub_cancel_right, pow_succ, Nat.add_sub_cancel]
+  ring
 
 variable {χ : TopEdgeLabelling V (Fin 2)}
 
@@ -208,14 +209,14 @@ properties which are needed for it
 -/
 structure BookConfig (χ : TopEdgeLabelling V (Fin 2)) where
   (X y A B : Finset V)
-  hXY : Disjoint X Y
+  hXY : Disjoint X y
   hXA : Disjoint X A
   hXB : Disjoint X B
-  hYA : Disjoint Y A
-  hYB : Disjoint Y B
+  hYA : Disjoint y A
+  hYB : Disjoint y B
   hAB : Disjoint A B
   red_a : χ.MonochromaticOf A 0
-  red_XYA : χ.MonochromaticBetween (X ∪ Y) A 0
+  red_XYA : χ.MonochromaticBetween (X ∪ y) A 0
   blue_b : χ.MonochromaticOf B 1
   blue_XB : χ.MonochromaticBetween X B 1
 
@@ -246,49 +247,43 @@ def redStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookConfig χ
   y := (red_neighbors χ) x ∩ C.y
   A := insert x C.A
   B := C.B
-  hXY := disjoint_of_subset_left (inter_subset_right _ _) (C.hXY.inf_right' _)
+  hXY := disjoint_of_subset_left (inter_subset_right) (C.hXY.inf_right' _)
   hXA := by
     rw [disjoint_insert_right, mem_inter, not_and_or]
-    refine' ⟨Or.inl not_mem_col_neighbors, _⟩
-    exact disjoint_of_subset_left (inter_subset_right _ _) C.hXA
-  hXB := disjoint_of_subset_left (inter_subset_right _ _) C.hXB
+    refine' ⟨Or.inl not_mem_colNeighbors, _⟩
+    exact disjoint_of_subset_left (inter_subset_right) C.hXA
+  hXB := disjoint_of_subset_left (inter_subset_right) C.hXB
   hYA := by
     rw [disjoint_insert_right, mem_inter, not_and_or]
-    refine' ⟨Or.inl not_mem_col_neighbors, _⟩
-    exact disjoint_of_subset_left (inter_subset_right _ _) C.hYA
-  hYB := disjoint_of_subset_left (inter_subset_right _ _) C.hYB
+    refine' ⟨Or.inl not_mem_colNeighbors, _⟩
+    exact disjoint_of_subset_left (inter_subset_right) C.hYA
+  hYB := disjoint_of_subset_left (inter_subset_right) C.hYB
   hAB := by
-    simp only [disjoint_insert_left, C.hAB, and_true_iff]
+    simp only [disjoint_insert_left, C.hAB, and_true]
     exact Finset.disjoint_left.1 C.hXB hx
   red_a := by
     have : x ∉ (C.A : Set V) := Finset.disjoint_left.1 C.hXA hx
-    rw [coe_insert, TopEdgeLabelling.MonochromaticOf_insert this, and_iff_right C.red_A]
+    rw [coe_insert, TopEdgeLabelling.monochromaticOf_insert this, and_iff_right C.red_a]
     intro a ha
-    exact C.red_XYA (mem_union_left _ hx) ha _
-  red_XYA :=
-    by
-    rw [← inter_distrib_left, insert_eq, TopEdgeLabelling.MonochromaticBetween_union_right,
-      TopEdgeLabelling.MonochromaticBetween_singleton_right]
-    constructor
-    · simp (config := { contextual := true }) [mem_col_neighbors']
-    · exact C.red_XYA.subset_left (inter_subset_right _ _)
+    exact C.red_XYA (Or.inl (by exact_mod_cast hx)) ha _
+  red_XYA := sorry
   blue_b := C.blue_b
-  blue_XB := C.blue_XB.subset_left (inter_subset_right _ _)
+  blue_XB := C.blue_XB.subset_left (Finset.coe_subset.2 inter_subset_right)
 
 theorem redStepBasic_x {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (redStepBasic C x hx).X = (red_neighbors χ) x ∩ C.X :=
-  rfl
+  by simp [redStepBasic]
 
 theorem redStepBasic_y {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (redStepBasic C x hx).y = (red_neighbors χ) x ∩ C.y :=
-  rfl
+  by simp [redStepBasic]
 
 theorem redStepBasic_a {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (redStepBasic C x hx).A = insert x C.A :=
-  rfl
+  by simp [redStepBasic]
 
 theorem redStepBasic_b {C : BookConfig χ} {x : V} (hx : x ∈ C.X) : (redStepBasic C x hx).B = C.B :=
-  rfl
+  by simp [redStepBasic]
 
 end
 
@@ -309,13 +304,18 @@ def bigBlueStepBasic (C : BookConfig χ) (S T : Finset V) (hS : S ⊆ C.X) (hT :
   hYB := disjoint_union_right.2 ⟨C.hYB, disjoint_of_subset_right hS C.hXY.symm⟩
   hAB := disjoint_union_right.2 ⟨C.hAB, disjoint_of_subset_right hS C.hXA.symm⟩
   red_a := C.red_a
-  red_XYA := C.red_XYA.subset_left (union_subset_union hT Subset.rfl)
+  red_XYA := C.red_XYA.subset_left (by
+    intro a ha
+    simp only [Set.mem_union] at ha
+    obtain ha | ha := ha
+    · exact Set.mem_union_left _ (Finset.coe_subset.2 hT ha)
+    · exact Set.mem_union_right _ ha)
   blue_b := by
-    rw [coe_union, TopEdgeLabelling.MonochromaticOf_union]
-    exact ⟨C.blue_B, hSS, C.blue_XB.symm.subset_right hS⟩
+    rw [coe_union, EdgeLabelling.monochromaticOf_union]
+    exact ⟨C.blue_b, hSS, C.blue_XB.symm.subset_right hS⟩
   blue_XB := by
-    rw [TopEdgeLabelling.MonochromaticBetween_union_right]
-    exact ⟨C.blue_XB.subset_left hT, hST'.symm⟩
+    rw [Finset.coe_union, EdgeLabelling.monochromaticBetween_union_right]
+    exact ⟨C.blue_XB.subset_left (Finset.coe_subset.2 hT), hST'.symm⟩
 
 variable [Fintype V]
 
@@ -330,41 +330,46 @@ def densityBoostStepBasic (C : BookConfig χ) (x : V) (hx : x ∈ C.X) : BookCon
   hXA := C.hXA.inf_left' _
   hXB := by
     rw [disjoint_insert_right, mem_inter, not_and_or]
-    exact ⟨Or.inl not_mem_col_neighbors, C.hXB.inf_left' _⟩
+    exact ⟨Or.inl not_mem_colNeighbors, C.hXB.inf_left' _⟩
   hYA := C.hYA.inf_left' _
   hYB := by
     rw [disjoint_insert_right, mem_inter, not_and_or]
-    exact ⟨Or.inl not_mem_col_neighbors, C.hYB.inf_left' _⟩
+    exact ⟨Or.inl not_mem_colNeighbors, C.hYB.inf_left' _⟩
   hAB := by
-    simp only [disjoint_insert_right, C.hAB, and_true_iff]
+    simp only [disjoint_insert_right, C.hAB, and_true]
     exact Finset.disjoint_left.1 C.hXA hx
   red_a := C.red_a
-  red_XYA :=
-    C.red_XYA.subset_left (union_subset_union (inter_subset_right _ _) (inter_subset_right _ _))
+  red_XYA := C.red_XYA.subset_left (by
+    intro a ha
+    simp only [Set.mem_union] at ha
+    obtain ha | ha := ha
+    · exact Set.mem_union_left _ (Finset.coe_subset.2 inter_subset_right ha)
+    · exact Set.mem_union_right _ (Finset.coe_subset.2 inter_subset_right ha))
   blue_b := by
-    rw [insert_eq, coe_union, MonochromaticOf_union, coe_singleton]
-    exact ⟨MonochromaticOf_singleton, C.blue_B, C.blue_XB.subset_left (by simpa using hx)⟩
+    rw [insert_eq, coe_union, EdgeLabelling.monochromaticOf_union, coe_singleton]
+    exact ⟨EdgeLabelling.monochromaticOf_singleton, C.blue_b, C.blue_XB.subset_left (by simpa using hx)⟩
   blue_XB :=
     by
-    rw [insert_eq, MonochromaticBetween_union_right, MonochromaticBetween_singleton_right]
-    refine' ⟨_, C.blue_XB.subset_left (inter_subset_right _ _)⟩
-    simp (config := { contextual := true }) [mem_col_neighbors']
+    rw [insert_eq, Finset.coe_union, Finset.coe_singleton,
+      EdgeLabelling.monochromaticBetween_union_right, EdgeLabelling.monochromaticBetween_singleton_right]
+    refine' ⟨_, C.blue_XB.subset_left (Finset.coe_subset.2 inter_subset_right)⟩
+    simp (config := { contextual := true }) [mem_colNeighbors']
 
 theorem densityBoostStepBasic_x {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (densityBoostStepBasic C x hx).X = (blue_neighbors χ) x ∩ C.X :=
-  rfl
+  by simp [densityBoostStepBasic]
 
 theorem densityBoostStepBasic_y {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (densityBoostStepBasic C x hx).y = (red_neighbors χ) x ∩ C.y :=
-  rfl
+  by simp [densityBoostStepBasic]
 
 theorem densityBoostStepBasic_a {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (densityBoostStepBasic C x hx).A = C.A :=
-  rfl
+  by simp [densityBoostStepBasic]
 
 theorem densityBoostStepBasic_b {C : BookConfig χ} {x : V} (hx : x ∈ C.X) :
     (densityBoostStepBasic C x hx).B = insert x C.B :=
-  rfl
+  by simp [densityBoostStepBasic]
 
 end
 
@@ -385,42 +390,48 @@ def degreeRegularisationStepBasic (C : BookConfig χ) (U : Finset V) (h : U ⊆ 
   hYB := C.hYB
   hAB := C.hAB
   red_a := C.red_a
-  red_XYA := C.red_XYA.subset_left (union_subset_union h Subset.rfl)
+  red_XYA := C.red_XYA.subset_left (by
+    intro a ha
+    simp only [Set.mem_union] at ha
+    obtain ha | ha := ha
+    · exact Set.mem_union_left _ (Finset.coe_subset.2 h ha)
+    · exact Set.mem_union_right _ ha)
   blue_b := C.blue_b
-  blue_XB := C.blue_XB.subset_left h
+  blue_XB := C.blue_XB.subset_left (Finset.coe_subset.2 h)
 
 variable [Fintype V]
 
 /-- Take a degree regularisation step, choosing the set of vertices as in the paper. -/
 noncomputable def degreeRegularisationStep (k : ℕ) (p₀ : ℝ) (C : BookConfig χ) : BookConfig χ :=
   degreeRegularisationStepBasic C
-    (C.X.filterₓ fun x =>
+    (C.X.filter fun x =>
       (C.p - k ^ (1 / 8 : ℝ) * αFunction k (height k p₀ C.p)) * C.y.card ≤
         ((red_neighbors χ) x ∩ C.y).card)
     (filter_subset _ _)
 
 theorem degreeRegularisationStep_x {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
     (degreeRegularisationStep k p₀ C).X =
-      C.X.filterₓ fun x =>
+      C.X.filter fun x =>
         (C.p - k ^ (1 / 8 : ℝ) * αFunction k (height k p₀ C.p)) * C.y.card ≤
           ((red_neighbors χ) x ∩ C.y).card :=
-  rfl
+  by simp [degreeRegularisationStep, degreeRegularisationStepBasic]
 
 theorem degreeRegularisationStep_y {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
     (degreeRegularisationStep k p₀ C).y = C.y :=
-  rfl
+  by simp [degreeRegularisationStep, degreeRegularisationStepBasic]
 
 theorem degreeRegularisationStep_a {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
     (degreeRegularisationStep k p₀ C).A = C.A :=
-  rfl
+  by simp [degreeRegularisationStep, degreeRegularisationStepBasic]
 
 theorem degreeRegularisationStep_b {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
     (degreeRegularisationStep k p₀ C).B = C.B :=
-  rfl
+  by simp [degreeRegularisationStep, degreeRegularisationStepBasic]
 
 theorem degreeRegularisationStep_x_subset {k : ℕ} {p₀ : ℝ} {C : BookConfig χ} :
-    (degreeRegularisationStep k p₀ C).X ⊆ C.X :=
-  filter_subset _ _
+    (degreeRegularisationStep k p₀ C).X ⊆ C.X := by
+  rw [degreeRegularisationStep_x]
+  exact filter_subset _ _
 
 end
 
@@ -428,7 +439,7 @@ end
 one of these later. -/
 noncomputable def usefulBlueBooks {V : Type*} [DecidableEq V] (χ : TopEdgeLabelling V (Fin 2))
     (μ : ℝ) (X : Finset V) : Finset (Finset V × Finset V) :=
-  (X.powerset.product X.powerset).filterₓ fun ST =>
+  (X.powerset.product X.powerset).filter fun ST =>
     Disjoint ST.1 ST.2 ∧
       χ.MonochromaticOf ST.1 1 ∧
         χ.MonochromaticBetween ST.1 ST.2 1 ∧ μ ^ ST.1.card * X.card / 2 ≤ ST.2.card
@@ -440,9 +451,9 @@ theorem mem_usefulBlueBooks {μ : ℝ} {X : Finset V} {ST : Finset V × Finset V
           Disjoint ST.1 ST.2 ∧
             χ.MonochromaticOf ST.1 1 ∧
               χ.MonochromaticBetween ST.1 ST.2 1 ∧ μ ^ ST.1.card * X.card / 2 ≤ ST.2.card :=
-  by rw [useful_blue_books, mem_filter, mem_product, mem_powerset, mem_powerset, and_assoc']
+  by rw [usefulBlueBooks, mem_filter]; constructor <;> simp [Finset.mem_product, mem_powerset] <;> tauto
 
-theorem mem_useful_blue_books' {μ : ℝ} {X S T : Finset V} :
+theorem mem_usefulBlueBooks' {μ : ℝ} {X S T : Finset V} :
     (S, T) ∈ usefulBlueBooks χ μ X ↔
       S ⊆ X ∧
         T ⊆ X ∧
@@ -454,10 +465,10 @@ theorem mem_useful_blue_books' {μ : ℝ} {X S T : Finset V} :
 theorem exists_useful_blue_book (μ : ℝ) (X : Finset V) : (usefulBlueBooks χ μ X).Nonempty :=
   by
   use(∅, X)
-  rw [mem_useful_blue_books']
-  simp only [empty_subset, subset.refl, disjoint_empty_left, coe_empty, MonochromaticOf_empty,
-    TopEdgeLabelling.MonochromaticBetween_empty_left, card_empty, pow_zero, one_mul,
-    true_and_iff]
+  rw [mem_usefulBlueBooks']
+  simp only [empty_subset, Subset.rfl, disjoint_empty_left, coe_empty, EdgeLabelling.monochromaticOf_empty,
+    EdgeLabelling.monochromaticBetween_empty_left, card_empty, pow_zero, one_mul,
+    true_and]
   exact half_le_self (Nat.cast_nonneg _)
 
 theorem exists_blue_book_one_le_S [Fintype V] (μ : ℝ) (X : Finset V)
@@ -465,23 +476,28 @@ theorem exists_blue_book_one_le_S [Fintype V] (μ : ℝ) (X : Finset V)
     ∃ ST : Finset V × Finset V, ST ∈ usefulBlueBooks χ μ X ∧ 1 ≤ ST.1.card :=
   by
   obtain ⟨x, hx, hx'⟩ := hX
-  cases lt_or_le μ 0
+  rcases lt_or_ge μ 0 with h | h
   · refine' ⟨⟨{x}, ∅⟩, _, by simp⟩
-    rw [mem_useful_blue_books']
-    simp only [singleton_subset_iff, empty_subset, disjoint_singleton_left, not_mem_empty,
-      not_false_iff, coe_singleton, MonochromaticOf_singleton, true_and_iff, hx, Nat.cast_zero,
-      TopEdgeLabelling.MonochromaticBetween_empty_right, card_singleton, pow_one, card_empty]
-    refine' div_nonpos_of_nonpos_of_nonneg (mul_nonpos_of_nonpos_of_nonneg h.le _) (by norm_num1)
-    positivity
+    rw [mem_usefulBlueBooks']
+    simp only [singleton_subset_iff, empty_subset, disjoint_singleton_left, Finset.notMem_empty,
+      not_false_iff, coe_singleton, EdgeLabelling.monochromaticOf_singleton, true_and, hx, Nat.cast_zero,
+      card_singleton, pow_one, card_empty]
+    constructor
+    · rw [Finset.coe_empty]; exact EdgeLabelling.monochromaticBetween_empty_right
+    · exact div_nonpos_of_nonpos_of_nonneg
+        (mul_nonpos_of_nonpos_of_nonneg (le_of_lt h) (Nat.cast_nonneg _))
+        (by norm_num : (0 : ℝ) ≤ 2)
   refine' ⟨⟨{x}, (blue_neighbors χ) x ∩ X⟩, _, by simp⟩
-  rw [mem_useful_blue_books']
+  rw [mem_usefulBlueBooks']
   simp (config := { contextual := true }) only [hx, singleton_subset_iff, disjoint_singleton_left,
-    mem_inter, and_true_iff, coe_singleton, MonochromaticOf_singleton, card_singleton, pow_one,
-    true_and_iff, inter_subset_right, not_true, not_mem_col_neighbors,
-    TopEdgeLabelling.MonochromaticBetween_singleton_left, and_imp, mem_col_neighbors, Ne.def,
-    eq_self_iff_true, not_false_iff, IsEmpty.exists_iff, forall_exists_index, imp_true_iff]
-  refine' hx'.trans' (half_le_self _)
-  positivity
+    mem_inter, and_true, coe_singleton, EdgeLabelling.monochromaticOf_singleton, card_singleton, pow_one,
+    true_and, inter_subset_right, not_false_iff, not_mem_colNeighbors,
+    EdgeLabelling.monochromaticBetween_singleton_left, and_imp, mem_colNeighbors,
+    eq_self_iff_true, IsEmpty.exists_iff, forall_exists_index, imp_true_iff]
+  constructor
+  · intro y hy h
+    sorry
+  · exact hx'.trans' (half_le_self (mul_nonneg h (Nat.cast_nonneg _)))
 
 theorem exists_maximal_blue_book_aux (χ : TopEdgeLabelling V (Fin 2)) (μ : ℝ) (X : Finset V) :
     ∃ ST ∈ usefulBlueBooks χ μ X,
@@ -492,10 +508,10 @@ theorem exists_maximal_blue_book_aux (χ : TopEdgeLabelling V (Fin 2)) (μ : ℝ
 /-- Get a maximal book contained in `X`. -/
 noncomputable def getBook (χ : TopEdgeLabelling V (Fin 2)) (μ : ℝ) (X : Finset V) :
     Finset V × Finset V :=
-  (exists_maximal_blue_book_aux χ μ X).some
+  (exists_maximal_blue_book_aux χ μ X).choose
 
 theorem getBook_mem (μ : ℝ) (X : Finset V) : getBook χ μ X ∈ usefulBlueBooks χ μ X :=
-  (exists_maximal_blue_book_aux χ μ X).choose_spec.some
+  (exists_maximal_blue_book_aux χ μ X).choose_spec.1
 
 theorem getBook_fst_subset {μ : ℝ} {X : Finset V} : (getBook χ μ X).1 ⊆ X :=
   (mem_usefulBlueBooks.1 (getBook_mem μ X)).1
@@ -519,7 +535,7 @@ theorem getBook_relative_card {μ : ℝ} {X : Finset V} :
 
 theorem getBook_max {μ : ℝ} {X : Finset V} (S T : Finset V) (hST : (S, T) ∈ usefulBlueBooks χ μ X) :
     S.card ≤ (getBook χ μ X).1.card :=
-  (exists_maximal_blue_book_aux χ μ X).choose_spec.choose_spec (S, T) hST
+  (exists_maximal_blue_book_aux χ μ X).choose_spec.2 (S, T) hST
 
 section
 
@@ -529,20 +545,19 @@ theorem one_le_card_getBook_fst {μ : ℝ} {X : Finset V}
     (hX : ∃ x ∈ X, μ * X.card ≤ ((blue_neighbors χ) x ∩ X).card) : 1 ≤ (getBook χ μ X).1.card :=
   by
   obtain ⟨⟨S, T⟩, hST, hS⟩ := exists_blue_book_one_le_S _ _ hX
-  exact hS.trans (get_book_max _ _ hST)
+  exact hS.trans (getBook_max _ _ hST)
 
 theorem getBook_snd_card_le_X {μ : ℝ} {X : Finset V}
     (hX : ∃ x ∈ X, μ * X.card ≤ ((blue_neighbors χ) x ∩ X).card) :
     (getBook χ μ X).2.card + 1 ≤ X.card :=
   by
-  refine' (add_le_add_left (one_le_card_get_book_fst hX) _).trans _
-  rw [add_comm, ← card_disjoint_union]
-  · exact card_le_of_subset (union_subset get_book_fst_subset get_book_snd_subset)
-  exact get_book_disjoints
+  refine' (add_le_add_right (one_le_card_getBook_fst hX) _).trans _
+  rw [add_comm, ← card_union_of_disjoint getBook_disjoints]
+  exact card_le_card (union_subset getBook_fst_subset getBook_snd_subset)
 
 /-- The number of vertices with a large blue neighbourhood. -/
 noncomputable def numBigBlues (μ : ℝ) (C : BookConfig χ) : ℕ :=
-  (C.X.filterₓ fun x => μ * C.X.card ≤ ((blue_neighbors χ) x ∩ C.X).card).card
+  (C.X.filter fun x => μ * C.X.card ≤ ((blue_neighbors χ) x ∩ C.X).card).card
 
 theorem get_book_condition {μ : ℝ} {k l : ℕ} {C : BookConfig χ} (hk : k ≠ 0) (hl : l ≠ 0)
     (hX : ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ numBigBlues μ C) :
@@ -550,11 +565,10 @@ theorem get_book_condition {μ : ℝ} {k l : ℕ} {C : BookConfig χ} (hk : k �
   by
   rw [← filter_nonempty_iff, ← card_pos]
   refine' hX.trans_lt' _
-  rw [ramsey_number_pos]
+  rw [ramseyNumber_pos]
   rw [Fin.forall_fin_two]
-  simp only [Matrix.cons_val_zero, Ne.def, Matrix.cons_val_one, Matrix.head_cons, Nat.ceil_eq_zero,
-    not_le, hk, not_false_iff, true_and_iff]
-  positivity
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
+  sorry
 
 end
 
@@ -564,17 +578,17 @@ noncomputable def bigBlueStep (μ : ℝ) (C : BookConfig χ) : BookConfig χ :=
     getBook_blue_fst getBook_disjoints getBook_blue_fst_snd
 
 theorem bigBlueStep_x {μ : ℝ} {C : BookConfig χ} : (bigBlueStep μ C).X = (getBook χ μ C.X).2 :=
-  rfl
+  by simp [bigBlueStep, bigBlueStepBasic]
 
 theorem bigBlueStep_y {μ : ℝ} {C : BookConfig χ} : (bigBlueStep μ C).y = C.y :=
-  rfl
+  by simp [bigBlueStep, bigBlueStepBasic]
 
 theorem bigBlueStep_a {μ : ℝ} {C : BookConfig χ} : (bigBlueStep μ C).A = C.A :=
-  rfl
+  by simp [bigBlueStep, bigBlueStepBasic]
 
 theorem bigBlueStep_b {μ : ℝ} {C : BookConfig χ} :
     (bigBlueStep μ C).B = C.B ∪ (getBook χ μ C.X).1 :=
-  rfl
+  by simp [bigBlueStep, bigBlueStepBasic]
 
 section
 
@@ -582,22 +596,22 @@ variable [Fintype V]
 
 /-- The set of viable central vertices. -/
 noncomputable def centralVertices (μ : ℝ) (C : BookConfig χ) : Finset V :=
-  C.X.filterₓ fun x => ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card
+  C.X.filter fun x => ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card
 
 theorem exists_central_vertex (μ : ℝ) (C : BookConfig χ)
     (hX : ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card) :
     ∃ x ∈ centralVertices μ C, ∀ y ∈ centralVertices μ C, weight χ C.X C.y y ≤ weight χ C.X C.y x :=
-  exists_max_image _ _ (by rwa [central_vertices, filter_nonempty_iff])
+  exists_max_image _ _ (by rwa [centralVertices, filter_nonempty_iff])
 
 /-- Get the central vertex as in step 3. -/
 noncomputable def getCentralVertex (μ : ℝ) (C : BookConfig χ)
     (hX : ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card) : V :=
-  (exists_central_vertex μ C hX).some
+  (exists_central_vertex μ C hX).choose
 
 theorem getCentralVertex_mem (μ : ℝ) (C : BookConfig χ)
     (hX : ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card) :
     getCentralVertex μ C hX ∈ centralVertices μ C :=
-  (exists_central_vertex μ C hX).choose_spec.some
+  (exists_central_vertex μ C hX).choose_spec.1
 
 theorem getCentralVertex_mem_x (μ : ℝ) (C : BookConfig χ)
     (hX : ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card) :
@@ -608,26 +622,13 @@ theorem getCentralVertex_max (μ : ℝ) (C : BookConfig χ)
     (hX : ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card) (y : V)
     (hy : y ∈ centralVertices μ C) :
     weight χ C.X C.y y ≤ weight χ C.X C.y (getCentralVertex μ C hX) :=
-  (exists_central_vertex μ C hX).choose_spec.choose_spec _ hy
+  (exists_central_vertex μ C hX).choose_spec.2 _ hy
 
-theorem get_central_vertex_condition {μ : ℝ} {k l : ℕ} (C : BookConfig χ)
+theorem getCentralVertex_condition {μ : ℝ} {k l : ℕ} (C : BookConfig χ)
     (h : ¬(C.X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨ C.p ≤ 1 / k))
     (h' : ¬ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ numBigBlues μ C) :
-    ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card :=
-  by
-  rw [not_or, not_le] at h
-  rw [not_le] at h'
-  rw [← filter_nonempty_iff, ← card_pos]
-  simp only [← not_lt]
-  rw [filter_not, card_sdiff (filter_subset _ _)]
-  refine' Nat.sub_pos_of_lt (h.1.trans_le' _)
-  refine' ((card_le_of_subset _).trans_lt h').le.trans _
-  · exact monotone_filter_right _ fun y hy => hy.le
-  refine' ramsey_number.mono_two le_rfl (Nat.ceil_mono _)
-  cases l
-  · rw [Nat.cast_zero, zero_rpow, zero_rpow] <;> norm_num1
-  refine' rpow_le_rpow_of_exponent_le _ (by norm_num1)
-  simp
+    ∃ x ∈ C.X, ↑((blue_neighbors χ) x ∩ C.X).card ≤ μ * C.X.card := by
+  sorry
 
 end
 
@@ -639,7 +640,7 @@ variable [Fintype V]
 noncomputable def algorithmOption (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : ℕ → Option (BookConfig χ)
   | 0 => some ini
   | i + 1 =>
-    match algorithm_option i with
+    match algorithmOption μ k l ini i with
     | none => none
     | some C =>
       if h : C.X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨ C.p ≤ 1 / k then none
@@ -650,7 +651,7 @@ noncomputable def algorithmOption (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) :
             if h' : ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ C.numBigBlues μ then
               C.bigBlueStep μ
             else
-              let x := C.getCentralVertex μ (C.get_central_vertex_condition h h')
+              let x := C.getCentralVertex μ (C.getCentralVertex_condition h h')
               if
                   C.p - αFunction k (height k ini.p C.p) ≤
                     (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y) then
@@ -660,80 +661,21 @@ noncomputable def algorithmOption (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) :
 variable {μ : ℝ} {k l : ℕ} {ini : BookConfig χ}
 
 theorem algorithmOption_stays_none {i : ℕ} (hi : algorithmOption μ k l ini i = none) :
-    algorithmOption μ k l ini (i + 1) = none :=
-  by
-  rw [algorithm_option, hi]
-  rfl
+    algorithmOption μ k l ini (i + 1) = none := by
+  unfold algorithmOption
+  rw [hi]
 
 theorem algorithmOption_is_some_of {i : ℕ} (hi : ∃ C, algorithmOption μ k l ini (i + 1) = some C) :
-    ∃ C, algorithmOption μ k l ini i = some C :=
-  by
-  contrapose! hi
-  simp only [Ne.def, ← Option.mem_def, ← Option.eq_none_iff_forall_not_mem] at hi ⊢
-  exact algorithm_option_stays_none hi
+    ∃ C, algorithmOption μ k l ini i = some C := by
+  sorry
 
 theorem algorithmOption_x_weak_bound {i : ℕ} (C : BookConfig χ) (hk : k ≠ 0) (hl : l ≠ 0)
-    (hC : algorithmOption μ k l ini i = some C) : C.X.card + i / 2 ≤ ini.X.card :=
-  by
-  induction' i with i ih generalizing C
-  · rw [Nat.zero_div, add_zero]
-    simp only [algorithm_option] at hC
-    rw [← hC]
-  obtain ⟨C', hC'⟩ := algorithm_option_is_some_of ⟨C, hC⟩
-  rw [algorithm_option, hC', algorithm_option._match_1] at hC
-  by_cases h₁ : C'.X.card ≤ ramsey_number ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨ C'.p ≤ 1 / k
-  · simpa only [dif_pos h₁] using hC
-  rw [dif_neg h₁] at hC
-  by_cases h₂ : Even i
-  · simp only [if_pos h₂] at hC
-    rw [even_iff_exists_bit0] at h₂
-    obtain ⟨i, rfl⟩ := h₂
-    rw [Nat.succ_eq_add_one, ← bit1, Nat.bit1_div_two, ← hC]
-    rw [Nat.bit0_div_two] at ih
-    exact (ih _ hC').trans' (add_le_add_right (card_le_of_subset (filter_subset _ _)) _)
-  rw [if_neg h₂] at hC
-  rw [← Nat.odd_iff_not_even, Odd] at h₂
-  obtain ⟨i, rfl⟩ := h₂
-  rw [Nat.succ_eq_add_one, add_assoc, ← two_mul, ← mul_add, ← bit0_eq_two_mul, Nat.bit0_div_two]
-  specialize ih _ hC'
-  rw [← bit0_eq_two_mul, ← bit1, Nat.bit1_div_two] at ih
-  refine' ih.trans' _
-  rw [← add_assoc, add_right_comm, add_le_add_iff_right]
-  split_ifs at hC  with h₂ h₃ h₄
-  · rw [← hC]
-    refine' book_config.get_book_snd_card_le_X _
-    exact book_config.get_book_condition hk hl h₂
-  · let x := C'.get_central_vertex μ (C'.get_central_vertex_condition h₁ h₂)
-    rw [← hC]
-    have : (red_neighbors χ) x ∩ C'.X ⊆ C'.X.erase x :=
-      by
-      rw [subset_erase]
-      refine' ⟨inter_subset_right _ _, _⟩
-      simp [not_mem_col_neighbors]
-    refine' (add_le_add_right (card_le_of_subset this) _).trans _
-    rw [card_erase_add_one]
-    exact book_config.get_central_vertex_mem_X _ _ _
-  · let x := C'.get_central_vertex μ (C'.get_central_vertex_condition h₁ h₂)
-    rw [← hC]
-    have : (blue_neighbors χ) x ∩ C'.X ⊆ C'.X.erase x :=
-      by
-      rw [subset_erase]
-      refine' ⟨inter_subset_right _ _, _⟩
-      simp [not_mem_col_neighbors]
-    refine' (add_le_add_right (card_le_of_subset this) _).trans _
-    rw [card_erase_add_one]
-    exact book_config.get_central_vertex_mem_X _ _ _
+    (hC : algorithmOption μ k l ini i = some C) : C.X.card + i / 2 ≤ ini.X.card := by
+  sorry
 
 theorem algorithmOption_terminates (μ : ℝ) (ini : BookConfig χ) (hk : k ≠ 0) (hl : l ≠ 0) :
-    ∃ i, algorithmOption μ k l ini (i + 1) = none :=
-  by
-  refine' ⟨bit0 (ini.X.card + 1), _⟩
-  rw [Option.eq_none_iff_forall_not_mem]
-  intro C hC
-  rw [Option.mem_def] at hC
-  have := algorithm_option_X_weak_bound C hk hl hC
-  rw [← bit1, Nat.bit1_div_two] at this
-  linarith only [this]
+    ∃ i, algorithmOption μ k l ini (i + 1) = none := by
+  sorry
 
 /-- The index of the final step. Also the number of steps the algorithm takes.
 The previous two sentences may have an off-by-one error.  -/
@@ -744,7 +686,7 @@ noncomputable def finalStep (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : ℕ :
 when initialised with `μ`, `k, l` and initial configuration `ini`.
 
 If we are *after* the termination has applied, this just gives `ini`. That is, this is the correct
-definition of the book algorithm *as long as* `i ≤ final_step μ k l ini`, in other words it's
+definition of the book algorithm *as long as* `i ≤ finalStep μ k l ini`, in other words it's
 correct as long as the book algorithm hasn't finished.
 -/
 noncomputable def algorithm (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) (i : ℕ) : BookConfig χ :=
@@ -758,64 +700,40 @@ variable {i : ℕ}
 
 theorem finalStep_is_none (hk : k ≠ 0) (hl : l ≠ 0) :
     algorithmOption μ k l ini (finalStep μ k l ini + 1) = none :=
-  haveI : {i | algorithm_option μ k l ini (i + 1) = none}.Nonempty :=
+  haveI : {i | algorithmOption μ k l ini (i + 1) = none}.Nonempty :=
     by
-    obtain ⟨i, hi⟩ := algorithm_option_terminates μ ini hk hl
+    obtain ⟨i, hi⟩ := algorithmOption_terminates μ ini hk hl
     exact ⟨i, hi⟩
   csInf_mem this
 
 theorem algorithm_zero : algorithm μ k l ini 0 = ini :=
-  by
-  rw [← Option.some_inj, algorithm, algorithm_option]
-  rfl
+  by simp [algorithm, algorithmOption]
 
 theorem some_algorithm_of_finalStep_le (hi : i ≤ finalStep μ k l ini) :
-    some (algorithm μ k l ini i) = algorithmOption μ k l ini i :=
-  by
-  cases i
-  · rw [algorithm_zero]
-    rfl
-  rw [Nat.succ_eq_add_one] at *
-  rw [algorithm, Option.getD_of_ne_none]
-  intro hi'
-  have : i ∈ {i | algorithm_option μ k l ini (i + 1) = none} := hi'
-  have : final_step μ k l ini ≤ i := Nat.sInf_le this
-  linarith
+    some (algorithm μ k l ini i) = algorithmOption μ k l ini i := by
+  sorry
 
 theorem condition_fails_at_end (hk : k ≠ 0) (hl : l ≠ 0) :
     (endState μ k l ini).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨
-      (endState μ k l ini).p ≤ 1 / k :=
-  by
-  by_contra h
-  have h' : some (end_state μ k l ini) = algorithm_option μ k l ini (final_step μ k l ini) :=
-    some_algorithm_of_final_step_le le_rfl
-  have : algorithm_option μ k l ini _ = none := final_step_is_none hk hl
-  rw [algorithm_option, ← h', algorithm_option._match_1] at this
-  simpa only [dif_neg h] using this
+      (endState μ k l ini).p ≤ 1 / k := by
+  sorry
 
 theorem succeed_of_finalStep_le' (hi : i < finalStep μ k l ini) :
     ¬((algorithm μ k l ini i).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨
-        (algorithm μ k l ini i).p ≤ 1 / k) :=
-  by
-  intro h''
-  have h : some (algorithm μ k l ini i) = algorithm_option μ k l ini i :=
-    some_algorithm_of_final_step_le hi.le
-  have h' : some (algorithm μ k l ini (i + 1)) = algorithm_option μ k l ini (i + 1) :=
-    some_algorithm_of_final_step_le hi
-  rw [algorithm_option, ← h, algorithm_option._match_1, dif_pos h''] at h'
-  simpa only using h'
+        (algorithm μ k l ini i).p ≤ 1 / k) := by
+  sorry
 
 theorem ramseyNumber_lt_of_lt_finalStep (hi : i < finalStep μ k l ini) :
     ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] < (algorithm μ k l ini i).X.card :=
   by
-  have := succeed_of_final_step_le' hi
+  have := succeed_of_finalStep_le' hi
   rw [not_or, not_le] at this
   exact this.1
 
 theorem one_div_k_lt_p_of_lt_finalStep (hi : i < finalStep μ k l ini) :
     1 / (k : ℝ) < (algorithm μ k l ini i).p :=
   by
-  have := succeed_of_final_step_le' hi
+  have := succeed_of_finalStep_le' hi
   rw [not_or, not_le, not_le] at this
   exact this.2
 
@@ -827,36 +745,32 @@ theorem algorithm_succ (hi : i < finalStep μ k l ini) :
         if h' : ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ C.numBigBlues μ then C.bigBlueStep μ
         else
           let x :=
-            C.getCentralVertex μ (C.get_central_vertex_condition (succeed_of_finalStep_le' hi) h')
+            C.getCentralVertex μ (C.getCentralVertex_condition (succeed_of_finalStep_le' hi) h')
           if
               C.p - αFunction k (height k ini.p C.p) ≤
                 (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y) then
             C.redStepBasic x (C.getCentralVertex_mem_x _ _)
-          else C.densityBoostStepBasic x (C.getCentralVertex_mem_x _ _) :=
-  by
-  have : some (algorithm μ k l ini i) = algorithm_option μ k l ini i :=
-    some_algorithm_of_final_step_le hi.le
-  rw [← Option.some_inj, some_algorithm_of_final_step_le hi, algorithm_option, ← this,
-    algorithm_option._match_1, dif_neg (succeed_of_final_step_le' hi)]
+          else C.densityBoostStepBasic x (C.getCentralVertex_mem_x _ _) := by
+  sorry
 
 /-- The set of degree regularisation steps. Note this is indexed differently than the paper. -/
 noncomputable def degreeSteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Finset ℕ :=
-  (range (finalStep μ k l ini)).filterₓ Even
+  (range (finalStep μ k l ini)).filter Even
 
 /-- The set of big blue steps. Note this is indexed differently than the paper. -/
 noncomputable def bigBlueSteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Finset ℕ :=
-  (range (finalStep μ k l ini)).filterₓ fun i =>
+  (range (finalStep μ k l ini)).filter fun i =>
     ¬Even i ∧ ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ (algorithm μ k l ini i).numBigBlues μ
 
 /-- The set of red or density steps. Note this is indexed differently than the paper. -/
 noncomputable def redOrDensitySteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Finset ℕ :=
-  (range (finalStep μ k l ini)).filterₓ fun i =>
+  (range (finalStep μ k l ini)).filter fun i =>
     ¬Even i ∧ (algorithm μ k l ini i).numBigBlues μ < ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊]
 
 theorem degreeSteps_disjoint_bigBlueSteps_union_redOrDensitySteps :
     Disjoint (degreeSteps μ k l ini) (bigBlueSteps μ k l ini ∪ redOrDensitySteps μ k l ini) :=
   by
-  rw [big_blue_steps, red_or_density_steps, ← filter_or, degree_steps, disjoint_filter]
+  rw [bigBlueSteps, redOrDensitySteps, ← filter_or, degreeSteps, disjoint_filter]
   intro i hi
   rw [← and_or_left, not_and', Classical.not_not]
   exact Function.const _
@@ -864,30 +778,30 @@ theorem degreeSteps_disjoint_bigBlueSteps_union_redOrDensitySteps :
 theorem bigBlueSteps_disjoint_redOrDensitySteps :
     Disjoint (bigBlueSteps μ k l ini) (redOrDensitySteps μ k l ini) :=
   by
-  rw [big_blue_steps, red_or_density_steps, disjoint_filter]
+  rw [bigBlueSteps, redOrDensitySteps, disjoint_filter]
   rintro x hx ⟨hx₁, hx₂⟩
   rw [not_and, not_lt]
   intro
   exact hx₂
 
-theorem of_mem_red_or_density_steps₁ {i : ℕ} (hi : i ∈ redOrDensitySteps μ k l ini) :
+theorem of_mem_redOrDensitySteps₁ {i : ℕ} (hi : i ∈ redOrDensitySteps μ k l ini) :
     ¬((algorithm μ k l ini i).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨
         (algorithm μ k l ini i).p ≤ 1 / k) :=
   by
-  rw [red_or_density_steps, mem_filter, mem_range] at hi
-  exact succeed_of_final_step_le' hi.1
+  rw [redOrDensitySteps, mem_filter, mem_range] at hi
+  exact succeed_of_finalStep_le' hi.1
 
-theorem of_mem_red_or_density_steps₂ {i : ℕ} (hi : i ∈ redOrDensitySteps μ k l ini) :
+theorem of_mem_redOrDensitySteps₂ {i : ℕ} (hi : i ∈ redOrDensitySteps μ k l ini) :
     ¬ramseyNumber ![k, ⌈(l : ℝ) ^ (2 / 3 : ℝ)⌉₊] ≤ (algorithm μ k l ini i).numBigBlues μ :=
   by
-  rw [red_or_density_steps, mem_filter, ← not_le] at hi
+  rw [redOrDensitySteps, mem_filter, ← not_le] at hi
   exact hi.2.2
 
 /-- The choice of `x` in a red or density step. -/
 noncomputable def getX (hi : i ∈ redOrDensitySteps μ k l ini) : V :=
   (algorithm μ k l ini i).getCentralVertex μ
-    ((algorithm μ k l ini i).get_central_vertex_condition (of_mem_red_or_density_steps₁ hi)
-      (of_mem_red_or_density_steps₂ hi))
+    ((algorithm μ k l ini i).getCentralVertex_condition (of_mem_redOrDensitySteps₁ hi)
+      (of_mem_redOrDensitySteps₂ hi))
 
 theorem getX_mem_centralVertices (i : ℕ) (hi : i ∈ redOrDensitySteps μ k l ini) :
     getX hi ∈ (algorithm μ k l ini i).centralVertices μ :=
@@ -895,18 +809,18 @@ theorem getX_mem_centralVertices (i : ℕ) (hi : i ∈ redOrDensitySteps μ k l 
 
 /-- The set of red steps. -/
 noncomputable def redSteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Finset ℕ :=
-  Finset.image coe <|
-    (redOrDensitySteps μ k l ini).attach.filterₓ fun i =>
-      let x := getX i.Prop
+  Finset.image (Subtype.val ·) <|
+    (redOrDensitySteps μ k l ini).attach.filter fun i =>
+      let x := getX i.2
       let C := algorithm μ k l ini i
       C.p - αFunction k (height k ini.p C.p) ≤
         (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y)
 
 /-- The set of density boost steps. -/
 noncomputable def densitySteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Finset ℕ :=
-  Finset.image coe <|
-    (redOrDensitySteps μ k l ini).attach.filterₓ fun i =>
-      let x := getX i.Prop
+  Finset.image (Subtype.val ·) <|
+    (redOrDensitySteps μ k l ini).attach.filter fun i =>
+      let x := getX i.2
       let C := algorithm μ k l ini i
       (red_density χ) ((red_neighbors χ) x ∩ C.X) ((red_neighbors χ) x ∩ C.y) <
         C.p - αFunction k (height k ini.p C.p)
@@ -914,53 +828,51 @@ noncomputable def densitySteps (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) : Fi
 theorem redSteps_subset_redOrDensitySteps : redSteps μ k l ini ⊆ redOrDensitySteps μ k l ini :=
   by
   intro i hi
-  rw [red_steps] at hi
+  rw [redSteps] at hi
   simp only [mem_image, exists_prop, mem_filter, mem_attach, Subtype.exists, exists_eq_right,
-    true_and_iff, exists_eq_right, exists_and_right, Subtype.coe_mk] at hi
-  obtain ⟨hi, -⟩ := hi
-  exact hi
+    true_and, exists_and_right, Subtype.coe_mk] at hi
+  exact hi.1
 
 theorem densitySteps_subset_redOrDensitySteps :
     densitySteps μ k l ini ⊆ redOrDensitySteps μ k l ini :=
   by
   intro i hi
-  rw [density_steps] at hi
+  rw [densitySteps] at hi
   simp only [mem_image, exists_prop, mem_filter, mem_attach, Subtype.exists, exists_eq_right,
-    true_and_iff, exists_eq_right, exists_and_right, Subtype.coe_mk] at hi
-  obtain ⟨hi, -⟩ := hi
-  exact hi
+    true_and, exists_and_right, Subtype.coe_mk] at hi
+  exact hi.1
 
 theorem redSteps_union_densitySteps :
     redSteps μ k l ini ∪ densitySteps μ k l ini = redOrDensitySteps μ k l ini :=
   by
   refine'
-    subset.antisymm
-      (union_subset red_steps_subset_red_or_density_steps density_steps_subset_red_or_density_steps)
+    Subset.antisymm
+      (union_subset redSteps_subset_redOrDensitySteps densitySteps_subset_redOrDensitySteps)
       _
-  rw [red_steps, density_steps, ← image_union, ← filter_or]
+  rw [redSteps, densitySteps, ← image_union, ← filter_or]
   intro i hi
   simp only [mem_image, Subtype.exists, Subtype.coe_mk, exists_prop, mem_filter, mem_attach,
-    true_and_iff, exists_eq_right, exists_and_right]
+    true_and, exists_eq_right, exists_and_right]
   refine' ⟨hi, _⟩
-  exact le_or_lt _ _
+  exact (Classical.em _).imp_right not_le.mp
 
 theorem redSteps_disjoint_densitySteps : Disjoint (redSteps μ k l ini) (densitySteps μ k l ini) :=
   by
-  rw [red_steps, density_steps, disjoint_image Subtype.coe_injective, disjoint_filter]
+  rw [redSteps, densitySteps, disjoint_image Subtype.coe_injective, disjoint_filter]
   intro x hx
   simp
 
 theorem degree_regularisation_applied {i : ℕ} (hi : i ∈ degreeSteps μ k l ini) :
     algorithm μ k l ini (i + 1) = (algorithm μ k l ini i).degreeRegularisationStep k ini.p :=
   by
-  rw [degree_steps, mem_filter, mem_range] at hi
+  rw [degreeSteps, mem_filter, mem_range] at hi
   rw [algorithm_succ hi.1]
   exact if_pos hi.2
 
 theorem big_blue_applied {i : ℕ} (hi : i ∈ bigBlueSteps μ k l ini) :
     algorithm μ k l ini (i + 1) = (algorithm μ k l ini i).bigBlueStep μ :=
   by
-  rw [big_blue_steps, mem_filter, mem_range] at hi
+  rw [bigBlueSteps, mem_filter, mem_range] at hi
   rw [algorithm_succ hi.1]
   dsimp
   rw [if_neg hi.2.1, dif_pos hi.2.2]
@@ -970,11 +882,11 @@ theorem red_applied {i : ℕ} (hi : i ∈ redSteps μ k l ini) :
       (algorithm μ k l ini i).redStepBasic (getX (redSteps_subset_redOrDensitySteps hi))
         (BookConfig.getCentralVertex_mem_x _ _ _) :=
   by
-  rw [red_steps, mem_image] at hi
-  simp only [Subtype.coe_mk, mem_filter, mem_attach, true_and_iff, exists_prop, Subtype.exists,
+  rw [redSteps, mem_image] at hi
+  simp only [Subtype.coe_mk, mem_filter, mem_attach, true_and, exists_prop, Subtype.exists,
     exists_and_right, exists_eq_right] at hi
   obtain ⟨hi', hi''⟩ := hi
-  rw [red_or_density_steps, mem_filter, ← not_le, mem_range] at hi'
+  rw [redOrDensitySteps, mem_filter, ← not_le, mem_range] at hi'
   rw [algorithm_succ hi'.1]
   dsimp
   rw [if_neg hi'.2.1, dif_neg hi'.2.2, if_pos]
@@ -987,11 +899,11 @@ theorem density_applied {i : ℕ} (hi : i ∈ densitySteps μ k l ini) :
         (getX (densitySteps_subset_redOrDensitySteps hi))
         (BookConfig.getCentralVertex_mem_x _ _ _) :=
   by
-  rw [density_steps, mem_image] at hi
-  simp only [Subtype.coe_mk, mem_filter, mem_attach, true_and_iff, exists_prop, Subtype.exists,
+  rw [densitySteps, mem_image] at hi
+  simp only [Subtype.coe_mk, mem_filter, mem_attach, true_and, exists_prop, Subtype.exists,
     exists_and_right, exists_eq_right] at hi
   obtain ⟨hi', hi''⟩ := hi
-  rw [red_or_density_steps, mem_filter, ← not_le, mem_range] at hi'
+  rw [redOrDensitySteps, mem_filter, ← not_le, mem_range] at hi'
   rw [algorithm_succ hi'.1]
   dsimp
   rw [if_neg hi'.2.1, dif_neg hi'.2.2, if_neg]
@@ -1002,29 +914,29 @@ theorem union_partial_steps :
     redOrDensitySteps μ k l ini ∪ bigBlueSteps μ k l ini ∪ degreeSteps μ k l ini =
       range (finalStep μ k l ini) :=
   by
-  rw [red_or_density_steps, big_blue_steps, ← filter_or, degree_steps, ← filter_or]
+  rw [redOrDensitySteps, bigBlueSteps, ← filter_or, degreeSteps, ← filter_or]
   refine' filter_true_of_mem _
   intro i hi
   rw [← and_or_left, and_iff_left]
   · exact em' _
-  exact lt_or_le _ _
+  exact lt_or_ge _ _
 
 theorem union_steps :
     redSteps μ k l ini ∪ bigBlueSteps μ k l ini ∪ densitySteps μ k l ini ∪ degreeSteps μ k l ini =
       range (finalStep μ k l ini) :=
-  by rw [union_right_comm (red_steps _ _ _ _), red_steps_union_density_steps, union_partial_steps]
+  by rw [union_right_comm (redSteps _ _ _ _), redSteps_union_densitySteps, union_partial_steps]
 
 theorem filter_even_thing {n : ℕ} :
-    ((range n).filterₓ Even).card ≤ ((range n).filterₓ fun i => ¬Even i).card + 1 :=
+    ((range n).filter Even).card ≤ ((range n).filter fun i => ¬Even i).card + 1 :=
   by
-  have : ((range n).filterₓ Even).image Nat.succ ⊆ (range (n + 1)).filterₓ fun i => ¬Even i :=
+  have : ((range n).filter Even).image Nat.succ ⊆ (range (n + 1)).filter fun i => ¬Even i :=
     by
-    simp only [Finset.subset_iff, mem_filter, mem_image, and_imp, exists_prop, and_assoc',
+    simp only [Finset.subset_iff, mem_filter, mem_image, and_imp, exists_prop, and_assoc,
       mem_range, forall_exists_index, Nat.succ_eq_add_one]
     rintro _ y hy hy' rfl
     simp [hy, hy', parity_simps]
   rw [← Finset.card_image_of_injective _ Nat.succ_injective]
-  refine' (card_le_of_subset this).trans _
+  refine' (card_le_card this).trans _
   rw [range_succ, filter_insert]
   split_ifs
   · exact Nat.le_succ _
@@ -1036,77 +948,70 @@ theorem num_degreeSteps_le_add :
         1 :=
   by
   have :
-    big_blue_steps μ k l ini ∪ red_or_density_steps μ k l ini =
-      (range (final_step μ k l ini)).filterₓ fun i => ¬Even i :=
+    bigBlueSteps μ k l ini ∪ redOrDensitySteps μ k l ini =
+      (range (finalStep μ k l ini)).filter fun i => ¬Even i :=
     by
-    rw [big_blue_steps, red_or_density_steps, ← filter_or]
+    rw [bigBlueSteps, redOrDensitySteps, ← filter_or]
     refine' filter_congr _
     intro i hi
     rw [← and_or_left, ← not_le, and_iff_left]
     exact em _
-  rw [add_right_comm _ _ (Finset.card _), ← card_disjoint_union red_steps_disjoint_density_steps,
-    red_steps_union_density_steps, add_comm _ (Finset.card _), ←
-    card_disjoint_union big_blue_steps_disjoint_red_or_density_steps, this, degree_steps]
+  rw [add_right_comm _ _ (Finset.card _), ← card_union_of_disjoint redSteps_disjoint_densitySteps,
+    redSteps_union_densitySteps, add_comm _ (Finset.card _), ←
+    card_union_of_disjoint bigBlueSteps_disjoint_redOrDensitySteps, this, degreeSteps]
   apply filter_even_thing
 
 theorem cases_of_lt_finalStep {i : ℕ} (hi : i < finalStep μ k l ini) :
     i ∈ redSteps μ k l ini ∨
       i ∈ bigBlueSteps μ k l ini ∨ i ∈ densitySteps μ k l ini ∨ i ∈ degreeSteps μ k l ini :=
-  by rwa [← mem_range, ← union_steps, mem_union, mem_union, mem_union, or_assoc', or_assoc'] at hi
+  by rwa [← mem_range, ← union_steps, mem_union, mem_union, mem_union, or_assoc, or_assoc] at hi
 
 -- (7)
 theorem x_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
     (algorithm μ k l ini (i + 1)).X ⊆ (algorithm μ k l ini i).X :=
   by
-  rcases cases_of_lt_final_step hi with (hi' | hi' | hi' | hi')
-  · rw [red_applied hi', book_config.red_step_basic_X]
-    exact inter_subset_right _ _
-  · rw [big_blue_applied hi', book_config.big_blue_step_X]
-    exact book_config.get_book_snd_subset
-  · rw [density_applied hi', book_config.density_boost_step_basic_X]
-    exact inter_subset_right _ _
-  · rw [degree_regularisation_applied hi', book_config.degree_regularisation_step_X]
-    exact book_config.degree_regularisation_step_X_subset
+  rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
+  · rw [red_applied hi', BookConfig.redStepBasic_x]
+    exact inter_subset_right
+  · rw [big_blue_applied hi', BookConfig.bigBlueStep_x]
+    exact BookConfig.getBook_snd_subset
+  · rw [density_applied hi', BookConfig.densityBoostStepBasic_x]
+    exact inter_subset_right
+  · rw [degree_regularisation_applied hi', BookConfig.degreeRegularisationStep_x]
+    exact BookConfig.degreeRegularisationStep_x_subset
 
 -- (7)
 theorem y_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
     (algorithm μ k l ini (i + 1)).y ⊆ (algorithm μ k l ini i).y :=
   by
-  rcases cases_of_lt_final_step hi with (hi' | hi' | hi' | hi')
-  · rw [red_applied hi', book_config.red_step_basic_Y]
-    exact inter_subset_right _ _
-  · rw [big_blue_applied hi', book_config.big_blue_step_Y]
-    rfl
-  · rw [density_applied hi', book_config.density_boost_step_basic_Y]
-    exact inter_subset_right _ _
-  · rw [degree_regularisation_applied hi', book_config.degree_regularisation_step_Y]
-    rfl
+  rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
+  · rw [red_applied hi', BookConfig.redStepBasic_y]
+    exact inter_subset_right
+  · rw [big_blue_applied hi', BookConfig.bigBlueStep_y]
+  · rw [density_applied hi', BookConfig.densityBoostStepBasic_y]
+    exact inter_subset_right
+  · rw [degree_regularisation_applied hi', BookConfig.degreeRegularisationStep_y]
 
 theorem a_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
     (algorithm μ k l ini i).A ⊆ (algorithm μ k l ini (i + 1)).A :=
   by
-  rcases cases_of_lt_final_step hi with (hi' | hi' | hi' | hi')
-  · rw [red_applied hi', book_config.red_step_basic_A]
+  rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
+  · rw [red_applied hi', BookConfig.redStepBasic_a]
     exact subset_insert _ _
-  · rw [big_blue_applied hi', book_config.big_blue_step_A]
-    rfl
-  · rw [density_applied hi', book_config.density_boost_step_basic_A]
-    rfl
-  · rw [degree_regularisation_applied hi', book_config.degree_regularisation_step_A]
-    rfl
+  · rw [big_blue_applied hi', BookConfig.bigBlueStep_a]
+  · rw [density_applied hi', BookConfig.densityBoostStepBasic_a]
+  · rw [degree_regularisation_applied hi', BookConfig.degreeRegularisationStep_a]
 
 theorem b_subset {i : ℕ} (hi : i < finalStep μ k l ini) :
     (algorithm μ k l ini i).B ⊆ (algorithm μ k l ini (i + 1)).B :=
   by
-  rcases cases_of_lt_final_step hi with (hi' | hi' | hi' | hi')
-  · rw [red_applied hi', book_config.red_step_basic_B]
-    rfl
-  · rw [big_blue_applied hi', book_config.big_blue_step_B]
-    exact subset_union_left _ _
-  · rw [density_applied hi', book_config.density_boost_step_basic_B]
+  rcases cases_of_lt_finalStep hi with (hi' | hi' | hi' | hi')
+  · rw [red_applied hi', BookConfig.redStepBasic_b]
+  · rw [big_blue_applied hi', BookConfig.bigBlueStep_b]
+    exact Finset.subset_union_left
+  · rw [density_applied hi', BookConfig.densityBoostStepBasic_b]
     exact subset_insert _ _
-  · rw [degree_regularisation_applied hi', book_config.degree_regularisation_step_B]
-    rfl
+  · rw [degree_regularisation_applied hi', BookConfig.degreeRegularisationStep_b]
 
 /-- Define `β` from the paper. -/
 noncomputable def blueXRatio (μ : ℝ) (k l : ℕ) (ini : BookConfig χ) (i : ℕ) : ℝ :=
@@ -1127,22 +1032,25 @@ theorem blueXRatio_prop (hi : i ∈ redOrDensitySteps μ k l ini) :
   by
   cases' Finset.eq_empty_or_nonempty (algorithm μ k l ini i).X with hX hX
   · rw [hX, inter_empty, card_empty, Nat.cast_zero, MulZeroClass.mul_zero]
-  rw [blue_X_ratio, dif_pos hi, div_mul_cancel]
+  rw [blueXRatio, dif_pos hi, div_mul_cancel₀]
   rwa [Nat.cast_ne_zero, ← pos_iff_ne_zero, card_pos]
 
-theorem blueXRatio_nonneg : 0 ≤ blueXRatio μ k l ini i := by rw [blue_X_ratio];
-  split_ifs <;> positivity
+theorem blueXRatio_nonneg : 0 ≤ blueXRatio μ k l ini i := by
+  rw [blueXRatio]
+  split_ifs
+  · positivity
+  · exact le_refl 0
 
 theorem blueXRatio_le_mu (hi : i ∈ redOrDensitySteps μ k l ini) : blueXRatio μ k l ini i ≤ μ :=
   by
-  rw [blue_X_ratio_eq hi]
-  have := get_x_mem_central_vertices i hi
-  rw [book_config.central_vertices, mem_filter] at this
-  rw [div_le_iff]
+  rw [blueXRatio_eq hi]
+  have := getX_mem_centralVertices i hi
+  rw [BookConfig.centralVertices, mem_filter] at this
+  rw [div_le_iff₀]
   · exact this.2
-  rw [red_or_density_steps, mem_filter, mem_range] at hi
+  rw [redOrDensitySteps, mem_filter, mem_range] at hi
   rw [Nat.cast_pos]
-  refine' (ramsey_number_lt_of_lt_final_step hi.1).trans_le' _
+  refine' (ramseyNumber_lt_of_lt_finalStep hi.1).trans_le' _
   exact Nat.zero_le _
 
 end SimpleGraph

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -684,44 +684,44 @@ theorem algorithmOption_x_weak_bound {i : ℕ} (C : BookConfig χ) (hk : k ≠ 0
     (hC : algorithmOption μ k l ini i = some C) : C.X.card + i / 2 ≤ ini.X.card := by
   induction i generalizing C with
   | zero =>
-      simp [algorithmOption] at hC
-      subst C
-      simp
+    simp [algorithmOption] at hC
+    subst C
+    simp
   | succ i ih =>
-      obtain ⟨C', hC'⟩ := algorithmOption_is_some_of ⟨C, hC⟩
-      unfold algorithmOption at hC
-      rw [hC'] at hC
-      simp only at hC
-      split_ifs at hC with hstop heven hbig hred
-      · injection hC with hC; subst C
-        have : (C'.degreeRegularisationStep k ini.p).X.card ≤ C'.X.card :=
-          card_le_card BookConfig.degreeRegularisationStep_x_subset
-        grind
-      · injection hC with hC; subst C
-        have : (C'.bigBlueStep μ).X.card + 1 ≤ C'.X.card := by
-          rw [BookConfig.bigBlueStep_x]
-          exact BookConfig.getBook_snd_card_le_X (BookConfig.get_book_condition hk hl hbig)
-        grind
-      · injection hC with hC; subst C
-        let x := C'.getCentralVertex μ (C'.getCentralVertex_condition hstop hbig)
-        have hx : x ∈ C'.X := BookConfig.getCentralVertex_mem_x _ _ _
-        have : ((red_neighbors χ) x ∩ C'.X).card < C'.X.card := by
-          refine card_lt_card ?_
-          exact (ssubset_iff_of_subset inter_subset_right).2
-            ⟨_, hx, by simp [not_mem_colNeighbors]⟩
-        have : (C'.redStepBasic x hx).X.card + 1 ≤ C'.X.card := by
-          rw [BookConfig.redStepBasic_x]; grind
-        grind
-      · injection hC with hC; subst C
-        let x := C'.getCentralVertex μ (C'.getCentralVertex_condition hstop hbig)
-        have hx : x ∈ C'.X := BookConfig.getCentralVertex_mem_x _ _ _
-        have : ((blue_neighbors χ) x ∩ C'.X).card < C'.X.card := by
-          refine card_lt_card ?_
-          exact (ssubset_iff_of_subset inter_subset_right).2
-            ⟨_, hx, by simp [not_mem_colNeighbors]⟩
-        have : (C'.densityBoostStepBasic x hx).X.card + 1 ≤ C'.X.card := by
-          rw [BookConfig.densityBoostStepBasic_x]; grind
-        grind
+    obtain ⟨C', hC'⟩ := algorithmOption_is_some_of ⟨C, hC⟩
+    unfold algorithmOption at hC
+    rw [hC'] at hC
+    simp only at hC
+    split_ifs at hC with hstop heven hbig hred
+    · injection hC with hC; subst C
+      have : (C'.degreeRegularisationStep k ini.p).X.card ≤ C'.X.card :=
+        card_le_card BookConfig.degreeRegularisationStep_x_subset
+      grind
+    · injection hC with hC; subst C
+      have : (C'.bigBlueStep μ).X.card + 1 ≤ C'.X.card := by
+        rw [BookConfig.bigBlueStep_x]
+        exact BookConfig.getBook_snd_card_le_X (BookConfig.get_book_condition hk hl hbig)
+      grind
+    · injection hC with hC; subst C
+      let x := C'.getCentralVertex μ (C'.getCentralVertex_condition hstop hbig)
+      have hx : x ∈ C'.X := BookConfig.getCentralVertex_mem_x _ _ _
+      have : ((red_neighbors χ) x ∩ C'.X).card < C'.X.card := by
+        refine card_lt_card ?_
+        exact (ssubset_iff_of_subset inter_subset_right).2
+          ⟨_, hx, by simp [not_mem_colNeighbors]⟩
+      have : (C'.redStepBasic x hx).X.card + 1 ≤ C'.X.card := by
+        rw [BookConfig.redStepBasic_x]; grind
+      grind
+    · injection hC with hC; subst C
+      let x := C'.getCentralVertex μ (C'.getCentralVertex_condition hstop hbig)
+      have hx : x ∈ C'.X := BookConfig.getCentralVertex_mem_x _ _ _
+      have : ((blue_neighbors χ) x ∩ C'.X).card < C'.X.card := by
+        refine card_lt_card ?_
+        exact (ssubset_iff_of_subset inter_subset_right).2
+          ⟨_, hx, by simp [not_mem_colNeighbors]⟩
+      have : (C'.densityBoostStepBasic x hx).X.card + 1 ≤ C'.X.card := by
+        rw [BookConfig.densityBoostStepBasic_x]; grind
+      grind
 
 theorem algorithmOption_terminates (μ : ℝ) (ini : BookConfig χ) (hk : k ≠ 0) (hl : l ≠ 0) :
     ∃ i, algorithmOption μ k l ini (i + 1) = none := by

--- a/ExponentialRamsey/Basic.lean
+++ b/ExponentialRamsey/Basic.lean
@@ -667,7 +667,12 @@ theorem algorithmOption_stays_none {i : ℕ} (hi : algorithmOption μ k l ini i 
 
 theorem algorithmOption_is_some_of {i : ℕ} (hi : ∃ C, algorithmOption μ k l ini (i + 1) = some C) :
     ∃ C, algorithmOption μ k l ini i = some C := by
-  sorry
+  by_contra h
+  push_neg at h
+  have h1 : algorithmOption μ k l ini i = none := Option.eq_none_iff_forall_not_mem.mpr h
+  have h2 : algorithmOption μ k l ini (i + 1) = none := algorithmOption_stays_none h1
+  obtain ⟨C, hC⟩ := hi
+  exact Option.some_ne_none C (h2 ▸ hC).symm
 
 theorem algorithmOption_x_weak_bound {i : ℕ} (C : BookConfig χ) (hk : k ≠ 0) (hl : l ≠ 0)
     (hC : algorithmOption μ k l ini i = some C) : C.X.card + i / 2 ≤ ini.X.card := by
@@ -675,7 +680,11 @@ theorem algorithmOption_x_weak_bound {i : ℕ} (C : BookConfig χ) (hk : k ≠ 0
 
 theorem algorithmOption_terminates (μ : ℝ) (ini : BookConfig χ) (hk : k ≠ 0) (hl : l ≠ 0) :
     ∃ i, algorithmOption μ k l ini (i + 1) = none := by
-  sorry
+  refine' ⟨2 * (ini.X.card + 1), _⟩
+  rw [Option.eq_none_iff_forall_not_mem]
+  intro C hC
+  have := algorithmOption_x_weak_bound C hk hl hC
+  omega
 
 /-- The index of the final step. Also the number of steps the algorithm takes.
 The previous two sentences may have an off-by-one error.  -/
@@ -711,7 +720,17 @@ theorem algorithm_zero : algorithm μ k l ini 0 = ini :=
 
 theorem some_algorithm_of_finalStep_le (hi : i ≤ finalStep μ k l ini) :
     some (algorithm μ k l ini i) = algorithmOption μ k l ini i := by
-  sorry
+  cases i with
+  | zero => simp [algorithm, algorithmOption]
+  | succ i =>
+    unfold algorithm
+    have hnotin : ¬(i ∈ {j | algorithmOption μ k l ini (j + 1) = none}) := by
+      intro hi'
+      have : finalStep μ k l ini ≤ i := Nat.sInf_le hi'
+      omega
+    cases h : algorithmOption μ k l ini (Nat.succ i) with
+    | none => exact absurd h hnotin
+    | some C => simp [Option.getD_some, h]
 
 theorem condition_fails_at_end (hk : k ≠ 0) (hl : l ≠ 0) :
     (endState μ k l ini).X.card ≤ ramseyNumber ![k, ⌈(l : ℝ) ^ (3 / 4 : ℝ)⌉₊] ∨


### PR DESCRIPTION
This PR finishes the port of `Basic.lean` file to Lean4, and solves the outstanding sorry's in the file. The file now compiles and is successfully imported in `ExponentialRamsey.lean`.

I have used the [`improve`](https://gist.github.com/b-mehta/b04175a5111dcab708d718fec3c2120d) skill after the changes.

Most of the porting was done by MiMo V2.5 Free in Opencode, and the final 5 sorry's and reviewing were done by GPT 5.5 with medium effort in Codex.