### PR TITLE
Port Log2Estimates to lean4

### DIFF
--- a/ExponentialRamsey.lean
+++ b/ExponentialRamsey.lean
@@ -1,5 +1,5 @@
 import ExponentialRamsey.Basic
--- import ExponentialRamsey.Log2Estimates
+import ExponentialRamsey.Log2Estimates
 -- import ExponentialRamsey.LogSmall
 -- import ExponentialRamsey.MainResults
 -- import ExponentialRamsey.NecessaryLogEstimates

--- a/ExponentialRamsey/Log2Estimates.lean
+++ b/ExponentialRamsey/Log2Estimates.lean
@@ -10,7 +10,6 @@ import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic
 # Estimates on log base 2 of rationals by iterative squaring
 -/
 
-
 noncomputable section
 
 open Real
@@ -54,7 +53,8 @@ theorem log_base2_weaken {x₁ x₂ a₁ a₂ : ℝ} (x₃ x₄ : ℝ) (h : LogB
 
 theorem log_base2_half {x₁ x₂ a₁ a₂ : ℝ} (h : LogBase2Goal (x₁ / 2) (x₂ / 2) (a₁ - 1) (a₂ - 1)) :
     LogBase2Goal x₁ x₂ a₁ a₂ := fun hx₁ hx₂ => by
-  simpa [logb_div_base', hx₁.ne', show (2 : ℝ) ≠ 1 by norm_num, (hx₁.trans_le hx₂).ne'] using
+  have h_two_ne_one : (2 : ℝ) ≠ 1 := by norm_num
+  simpa [logb_div_base', hx₁.ne', h_two_ne_one, (hx₁.trans_le hx₂).ne'] using
     h (half_pos hx₁) (div_le_div_of_nonneg_right hx₂ zero_le_two)
 
 theorem log_base2_scale {x₁ x₂ a₁ a₂ : ℝ} (m : ℤ)
@@ -64,7 +64,7 @@ theorem log_base2_scale {x₁ x₂ a₁ a₂ : ℝ} (m : ℤ)
   have i : 0 < (2 : ℝ) ^ m := zpow_pos zero_lt_two _
   have := h (mul_pos hx₁ i) (mul_le_mul_of_nonneg_right hx₂ i.le)
   simpa [logb_mul hx₁.ne' i.ne', logb_mul (hx₁.trans_le hx₂).ne' i.ne', logb_zpow, logb_base,
-    show (2 : ℝ) ≠ 1 by norm_num] using this
+    (by norm_num : (2 : ℝ) ≠ 1)] using this
 
 theorem log_base2_start {x₁ x₂ a₁ a₂ : ℝ} (hx₁ : 0 < x₁) (hx₂ : x₁ ≤ x₂)
     (h : LogBase2Goal x₁ x₂ a₁ a₂) : a₁ < logb 2 x₁ ∧ logb 2 x₂ < a₂ :=

--- a/ExponentialRamsey/Log2Estimates.lean
+++ b/ExponentialRamsey/Log2Estimates.lean
@@ -14,18 +14,9 @@ noncomputable section
 
 open Real
 
-theorem logb_pow {b x : ℝ} (m : ℕ) : logb b (x ^ m) = m * logb b x := by
-  rw [logb, log_pow, mul_div_assoc, logb]
-
-theorem logb_zpow {b x : ℝ} (m : ℤ) : logb b (x ^ m) = m * logb b x := by
-  rw [logb, log_zpow, mul_div_assoc, logb]
-
-theorem log_le_log_of_le {x y : ℝ} (hx : 0 < x) (hy : x ≤ y) : log x ≤ log y :=
-  Real.log_le_log hx hy
-
 theorem logb_le_logb_of_le {b x y : ℝ} (hb : 1 ≤ b) (hx : 0 < x) (hy : x ≤ y) :
     logb b x ≤ logb b y :=
-  div_le_div_of_nonneg_right (log_le_log_of_le hx hy) (log_nonneg hb)
+  div_le_div_of_nonneg_right (Real.log_le_log hx hy) (log_nonneg hb)
 
 theorem logb_base {b : ℝ} (hb : 0 < b) (hb' : b ≠ 1) : logb b b = 1 :=
   div_self (log_ne_zero_of_pos_of_ne_one hb hb')
@@ -40,7 +31,7 @@ def LogBase2Goal (x₁ x₂ a₁ a₂ : ℝ) : Prop :=
 
 theorem log_base2_square {x₁ x₂ a₁ a₂ : ℝ} (h : LogBase2Goal (x₁ ^ 2) (x₂ ^ 2) (2 * a₁) (2 * a₂)) :
     LogBase2Goal x₁ x₂ a₁ a₂ := fun hx₁ hx₂ => by
-  simpa [_root_.logb_pow] using h (pow_pos hx₁ _) (pow_le_pow_left₀ hx₁.le hx₂ _)
+  simpa [logb_pow] using h (pow_pos hx₁ _) (pow_le_pow_left₀ hx₁.le hx₂ _)
 
 theorem log_base2_weaken {x₁ x₂ a₁ a₂ : ℝ} (x₃ x₄ : ℝ) (h : LogBase2Goal x₃ x₄ a₁ a₂) (h₁ : x₃ ≤ x₁)
     (h₂ : x₂ ≤ x₄) (h₃ : 0 < x₃) : LogBase2Goal x₁ x₂ a₁ a₂ :=

--- a/ExponentialRamsey/Log2Estimates.lean
+++ b/ExponentialRamsey/Log2Estimates.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta
 -/
-import Analysis.SpecialFunctions.Log.Deriv
-import Analysis.SpecialFunctions.Log.Base
+import Mathlib.Analysis.SpecialFunctions.Log.Base
+import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic
 
 /-!
 # Estimates on log base 2 of rationals by iterative squaring
@@ -22,15 +22,16 @@ theorem logb_zpow {b x : ℝ} (m : ℤ) : logb b (x ^ m) = m * logb b x := by
   rw [logb, log_zpow, mul_div_assoc, logb]
 
 theorem log_le_log_of_le {x y : ℝ} (hx : 0 < x) (hy : x ≤ y) : log x ≤ log y :=
-  (log_le_log hx (hx.trans_le hy)).2 hy
+  Real.log_le_log hx hy
 
 theorem logb_le_logb_of_le {b x y : ℝ} (hb : 1 ≤ b) (hx : 0 < x) (hy : x ≤ y) :
     logb b x ≤ logb b y :=
-  div_le_div_of_le (log_nonneg hb) (log_le_log_of_le hx hy)
+  div_le_div_of_nonneg_right (log_le_log_of_le hx hy) (log_nonneg hb)
 
 theorem logb_base {b : ℝ} (hb : 0 < b) (hb' : b ≠ 1) : logb b b = 1 :=
   div_self (log_ne_zero_of_pos_of_ne_one hb hb')
 
+/-- Variant of `Real.logb_div_base` for dividing the argument by its base. -/
 theorem logb_div_base' {b x : ℝ} (hb : 0 < b) (hb' : b ≠ 1) (hx : x ≠ 0) :
     logb b (x / b) = logb b x - 1 := by rw [logb_div hx hb.ne', logb_base hb hb']
 
@@ -40,7 +41,7 @@ def LogBase2Goal (x₁ x₂ a₁ a₂ : ℝ) : Prop :=
 
 theorem log_base2_square {x₁ x₂ a₁ a₂ : ℝ} (h : LogBase2Goal (x₁ ^ 2) (x₂ ^ 2) (2 * a₁) (2 * a₂)) :
     LogBase2Goal x₁ x₂ a₁ a₂ := fun hx₁ hx₂ => by
-  simpa [logb_pow] using h (pow_pos hx₁ _) (pow_le_pow_of_le_left hx₁.le hx₂ _)
+  simpa [_root_.logb_pow] using h (pow_pos hx₁ _) (pow_le_pow_left₀ hx₁.le hx₂ _)
 
 theorem log_base2_weaken {x₁ x₂ a₁ a₂ : ℝ} (x₃ x₄ : ℝ) (h : LogBase2Goal x₃ x₄ a₁ a₂) (h₁ : x₃ ≤ x₁)
     (h₂ : x₂ ≤ x₄) (h₃ : 0 < x₃) : LogBase2Goal x₁ x₂ a₁ a₂ :=
@@ -54,13 +55,13 @@ theorem log_base2_weaken {x₁ x₂ a₁ a₂ : ℝ} (x₃ x₄ : ℝ) (h : LogB
 theorem log_base2_half {x₁ x₂ a₁ a₂ : ℝ} (h : LogBase2Goal (x₁ / 2) (x₂ / 2) (a₁ - 1) (a₂ - 1)) :
     LogBase2Goal x₁ x₂ a₁ a₂ := fun hx₁ hx₂ => by
   simpa [logb_div_base', hx₁.ne', show (2 : ℝ) ≠ 1 by norm_num, (hx₁.trans_le hx₂).ne'] using
-    h (half_pos hx₁) (div_le_div_of_le zero_le_two hx₂)
+    h (half_pos hx₁) (div_le_div_of_nonneg_right hx₂ zero_le_two)
 
 theorem log_base2_scale {x₁ x₂ a₁ a₂ : ℝ} (m : ℤ)
     (h : LogBase2Goal (x₁ * 2 ^ m) (x₂ * 2 ^ m) (a₁ + m) (a₂ + m)) : LogBase2Goal x₁ x₂ a₁ a₂ :=
   by
   intro hx₁ hx₂
-  have i : 0 < (2 : ℝ) ^ m := zpow_pos_of_pos zero_lt_two _
+  have i : 0 < (2 : ℝ) ^ m := zpow_pos zero_lt_two _
   have := h (mul_pos hx₁ i) (mul_le_mul_of_nonneg_right hx₂ i.le)
   simpa [logb_mul hx₁.ne' i.ne', logb_mul (hx₁.trans_le hx₂).ne' i.ne', logb_zpow, logb_base,
     show (2 : ℝ) ≠ 1 by norm_num] using this
@@ -76,18 +77,3 @@ theorem log_base2_end {x₁ x₂ a₁ a₂ : ℝ} (hx₁ : 1 < x₁) (hx₂ : x�
   refine' ⟨ha₁.trans_lt (div_pos (log_pos hx₁) (log_pos one_lt_two)), lt_of_lt_of_le _ ha₂⟩
   rw [logb, div_lt_one (log_pos one_lt_two)]
   exact log_lt_log ((zero_le_one.trans_lt hx₁).trans_le h) hx₂
-
-namespace Tactic
-
-namespace Interactive
-
-/- ./././Mathport/Syntax/Translate/Tactic/Mathlib/Core.lean:38:34: unsupported: setup_tactic_parser -/
-/- ./././Mathport/Syntax/Translate/Expr.lean:337:4: warning: unsupported (TODO): `[tacs] -/
-/-- a quick macro to simplify log2 estimate proofs -/
-unsafe def weaken (t u : parse parser.pexpr) : tactic Unit :=
-  sorry
-
-end Interactive
-
-end Tactic
-

--- a/ExponentialRamsey/Log2Estimates.lean
+++ b/ExponentialRamsey/Log2Estimates.lean
@@ -58,8 +58,7 @@ theorem log_base2_half {x₁ x₂ a₁ a₂ : ℝ} (h : LogBase2Goal (x₁ / 2) 
     h (half_pos hx₁) (div_le_div_of_nonneg_right hx₂ zero_le_two)
 
 theorem log_base2_scale {x₁ x₂ a₁ a₂ : ℝ} (m : ℤ)
-    (h : LogBase2Goal (x₁ * 2 ^ m) (x₂ * 2 ^ m) (a₁ + m) (a₂ + m)) : LogBase2Goal x₁ x₂ a₁ a₂ :=
-  by
+    (h : LogBase2Goal (x₁ * 2 ^ m) (x₂ * 2 ^ m) (a₁ + m) (a₂ + m)) : LogBase2Goal x₁ x₂ a₁ a₂ := by
   intro hx₁ hx₂
   have i : 0 < (2 : ℝ) ^ m := zpow_pos zero_lt_two _
   have := h (mul_pos hx₁ i) (mul_le_mul_of_nonneg_right hx₂ i.le)
@@ -71,8 +70,7 @@ theorem log_base2_start {x₁ x₂ a₁ a₂ : ℝ} (hx₁ : 0 < x₁) (hx₂ : 
   h hx₁ hx₂
 
 theorem log_base2_end {x₁ x₂ a₁ a₂ : ℝ} (hx₁ : 1 < x₁) (hx₂ : x₂ < 2) (ha₁ : a₁ ≤ 0)
-    (ha₂ : 1 ≤ a₂) : LogBase2Goal x₁ x₂ a₁ a₂ :=
-  by
+    (ha₂ : 1 ≤ a₂) : LogBase2Goal x₁ x₂ a₁ a₂ := by
   rintro - h
   refine' ⟨ha₁.trans_lt (div_pos (log_pos hx₁) (log_pos one_lt_two)), lt_of_lt_of_le _ ha₂⟩
   rw [logb, div_lt_one (log_pos one_lt_two)]

--- a/ExponentialRamsey/Log2Estimates.lean
+++ b/ExponentialRamsey/Log2Estimates.lean
@@ -69,3 +69,18 @@ theorem log_base2_end {x₁ x₂ a₁ a₂ : ℝ} (hx₁ : 1 < x₁) (hx₂ : x�
   refine' ⟨ha₁.trans_lt (div_pos (log_pos hx₁) (log_pos one_lt_two)), lt_of_lt_of_le _ ha₂⟩
   rw [logb, div_lt_one (log_pos one_lt_two)]
   exact log_lt_log ((zero_le_one.trans_lt hx₁).trans_le h) hx₂
+
+-- TODO: either temporarily restore `weaken` macro, or create a log library under b-mehta somewhere
+-- namespace Tactic
+--
+-- namespace Interactive
+--
+-- /- ./././Mathport/Syntax/Translate/Tactic/Mathlib/Core.lean:38:34: unsupported: setup_tactic_parser -/
+-- /- ./././Mathport/Syntax/Translate/Expr.lean:337:4: warning: unsupported (TODO): `[tacs] -/
+-- /-- a quick macro to simplify log2 estimate proofs -/
+-- unsafe def weaken (t u : parse parser.pexpr) : tactic Unit :=
+--   sorry
+--
+-- end Interactive
+--
+-- end Tactic

--- a/ExponentialRamsey/Log2Estimates.lean
+++ b/ExponentialRamsey/Log2Estimates.lean
@@ -14,6 +14,9 @@ noncomputable section
 
 open Real
 
+theorem logb_zpow {b x : ℝ} (m : ℤ) : logb b (x ^ m) = m * logb b x := by
+  rw [logb, log_zpow, mul_div_assoc, logb]
+
 theorem logb_le_logb_of_le {b x y : ℝ} (hb : 1 ≤ b) (hx : 0 < x) (hy : x ≤ y) :
     logb b x ≤ logb b y :=
   div_le_div_of_nonneg_right (Real.log_le_log hx hy) (log_nonneg hb)


### PR DESCRIPTION
This PR ports Log2Estimates.lean to lean4.

I have asked MiMo V3 Free to identify results that are already in Mathlib and remove them.