### PR TITLE
Ignore .lake build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /lake-packages/*
+/.lake


### PR DESCRIPTION
Adds /.lake to .gitignore so the Lake build cache directory isn't tracked.